### PR TITLE
Run jest only once while running all tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,3 +1,5 @@
+.DEFAULT_GOAL := test
+
 # assignments
 ASSIGNMENT ?= ""
 IGNOREDIRS := "^(\.git|docs|bin|node_modules|.idea)$$"

--- a/Makefile
+++ b/Makefile
@@ -4,24 +4,29 @@ IGNOREDIRS := "^(\.git|docs|bin|node_modules|.idea)$$"
 ASSIGNMENTS = $(shell find ./exercises -maxdepth 1 -mindepth 1 -type d | cut -d'/' -f3 | sort | grep -Ev $(IGNOREDIRS))
 
 # output directories
-OUTDIR ?= "exercises/$(ASSIGNMENT)/tmp"
+OUTDIR ?= "tmp_exercises/$(ASSIGNMENT)"
 
 # language specific config (tweakable per language)
 FILEEXT := "js"
 EXAMPLE := "example.$(FILEEXT)"
 TSTFILE := "$(subst _,-,$(ASSIGNMENT)).spec.$(FILEEXT)"
 
-test-assignment:
+copy-assignment:
 	@cp package.json exercises/$(ASSIGNMENT)
-	@echo "running tests for: $(ASSIGNMENT)"
 	@mkdir -p $(OUTDIR)
 	@cp exercises/grains/lib/big-integer.$(FILEEXT) $(OUTDIR)
 	@cp exercises/$(ASSIGNMENT)/$(TSTFILE) $(OUTDIR)
 	@cp exercises/$(ASSIGNMENT)/$(EXAMPLE) $(OUTDIR)/$(subst _,-,$(ASSIGNMENT)).$(FILEEXT)
 	@sed 's/xit/it/g' exercises/$(ASSIGNMENT)/$(TSTFILE) > $(OUTDIR)/temp.$(TSTFILE)
-	@node_modules/.bin/jest $(OUTDIR)/temp.*.spec.js
-	@rm $(OUTDIR)/*
-	@rmdir $(OUTDIR)
+
+# To be run as: make test-assignment ASSIGNMENT=hello-world
+test-assignment:
+	$(MAKE) -s copy-assignment
+	@node_modules/.bin/jest $(OUTDIR)
+	@rm -rf $(OUTDIR)
 
 test:
-	@for assignment in $(ASSIGNMENTS); do ASSIGNMENT=$$assignment $(MAKE) -s test-assignment || exit 1; done
+	@echo "Preparing tests..."
+	@for assignment in $(ASSIGNMENTS); do ASSIGNMENT=$$assignment $(MAKE) -s copy-assignment || exit 1; done
+	@node_modules/.bin/jest $(OUTDIR)
+	@rm -rf $(OUTDIR)


### PR DESCRIPTION
I am using a single directory named `tmp_exercises` and dumping all exercise and test files there. This makes it easy to run `jest` command over the entire directory in one-shot instead of running it over single exercise.

Speeds up the tests considerably - which means faster builds! 🎉 

**Before:**
`make test  106.12s user 24.49s system 101% cpu 2:09.03 total`

**After:**
`make test  20.53s user 2.75s system 106% cpu 21.872 total`

This is possible because jest parallelizes tests across workers.

Also added default target to Makefile. Which means we can run `make` instead of `make test`.