### PR TITLE
Add exercise List-Ops

### DIFF
--- a/config.json
+++ b/config.json
@@ -314,6 +314,15 @@
       ]
     },
     {
+      "slug": "list-ops",
+      "difficulty": 5,
+      "topics": [
+        "Data structures",
+        "Lists",
+        "Loops"
+      ]
+    },
+    {
       "slug": "binary-search-tree",
       "difficulty": 1,
       "topics": [

--- a/exercises/list-ops/example.js
+++ b/exercises/list-ops/example.js
@@ -1,0 +1,77 @@
+class List {
+
+  constructor(arr){
+    this.values = arr || [];
+  }
+
+  append(otherList){
+    for (let el of otherList.values){
+      this.values.push(el);
+    }
+    return this;
+  }
+
+  concat(otherList){
+    return this.append(otherList);
+  }
+
+  filter(operation){
+    const filteredValues = [];
+    for (let el of this.values){
+      if (operation(el)){
+        filteredValues.push(el);
+      }
+    }
+    this.values = filteredValues;
+    return this;
+  }
+
+  length(){
+    let length = 0;
+    for (let el of this.values){
+      length++;
+    }
+    return length;
+  }
+
+  map(operation){
+    const mappedValues = [];
+    for (let el of this.values){
+      mappedValues.push(operation(el));
+    }
+    this.values = mappedValues;
+    return this;
+  }
+
+  foldl(operation, initialValue){
+    let acc = initialValue;
+    for (let el of this.values){
+      acc = operation(acc, el);
+    }
+    return acc;
+  }
+
+  foldr(operation, initialValue){
+    let acc = initialValue;
+    let index = this.length() -1;
+    while (index >= 0){
+      let el = this.values[index--];
+      acc = operation(acc, el);
+    }
+    return acc;
+  }
+
+  reverse(){
+    const numElements = this.length();
+    let finalIndex = numElements - 1;
+    for (let index = 0; index < numElements/2; index++){
+      const temp = this.values[index];
+      this.values[index] = this.values[finalIndex];
+      this.values[finalIndex--] = temp;
+    }
+    return this;
+  }
+
+}
+
+export default List;

--- a/exercises/list-ops/list-ops.spec.js
+++ b/exercises/list-ops/list-ops.spec.js
@@ -1,0 +1,133 @@
+import List from './list-ops';
+
+
+describe('append entries to a list and return the new list', () => {
+
+  it('empty lists', () => {
+    const list1 = new List();
+    const list2 = new List();
+    expect(list1.append(list2)).toEqual(new List());
+  });
+
+  xit('empty list to list', () => {
+    const list1 = new List([1, 2, 3, 4]);
+    const list2 = new List();
+    expect(list1.append(list2)).toEqual(list1);
+  });
+
+  xit('non-empty lists', () => {
+    const list1 = new List([1, 2]);
+    const list2 = new List([2, 3, 4, 5]);
+    expect(list1.append(list2).values).toEqual([1, 2, 2, 3, 4, 5]);
+  });
+
+});
+
+
+describe('concat lists and lists of lists into new list', () => {
+
+  xit('empty list', () => {
+    const list1 = new List();
+    const list2 = new List();
+    expect(list1.concat(list2).values).toEqual([]);
+  });
+
+  xit('list of lists', () => {
+    const list1 = new List([1, 2]);
+    const list2 = new List([3]);
+    const list3 = new List([]);
+    const list4 = new List([4, 5, 6]);
+    expect(list1.concat(list2).concat(list3).concat(list4).values).toEqual([1, 2, 3, 4, 5, 6]);
+  });
+
+});
+
+
+describe('filter list returning only values that satisfy the filter function', () => {
+
+  xit('empty list', () => {
+    const list1 = new List([]);
+    expect(list1.filter((el) => el % 2 === 1).values).toEqual([]);
+  });
+
+  xit('non empty list', () => {
+    const list1 = new List([1, 2, 3, 5]);
+    expect(list1.filter((el) => el % 2 === 1).values).toEqual([1, 3, 5]);
+  });
+
+});
+
+
+describe('returns the length of a list', () => {
+
+  xit('empty list', () => {
+    const list1 = new List();
+    expect(list1.length()).toEqual(0);
+  });
+
+  xit('non-empty list', () => {
+    const list1 = new List([1, 2, 3, 4]);
+    expect(list1.length()).toEqual(4);
+  });
+
+});
+
+
+describe('returns a list of elements whose values equal the list value transformed by the mapping function', () => {
+
+  xit('empty list', () => {
+    const list1 = new List();
+    expect(list1.map(el => ++el).values).toEqual([]);
+  });
+
+  xit('non-empty list', () => {
+    const list1 = new List([1, 3, 5, 7]);
+    expect(list1.map(el => ++el).values).toEqual([2, 4, 6, 8]);
+  });
+
+});
+
+
+describe('folds (reduces) the given list from the left with a function', () => {
+
+  xit('empty list', () => {
+    const list1 = new List();
+    expect(list1.foldl((acc, el) => el / acc, 2)).toEqual(2);
+  });
+
+  xit('division of integers', () => {
+    const list1 = new List([1, 2, 3, 4]);
+    expect(list1.foldl((acc, el) => el / acc, 24)).toEqual(64);
+  });
+
+});
+
+
+describe('folds (reduces) the given list from the right with a function', () => {
+
+  xit('empty list', () => {
+    const list1 = new List();
+    expect(list1.foldr((acc, el) => el / acc, 2)).toEqual(2);
+  });
+
+  xit('division of integers', () => {
+    const list1 = new List([1, 2, 3, 4]);
+    expect(list1.foldr((acc, el) => el / acc, 24)).toEqual(9);
+  });
+
+});
+
+
+describe('reverse the elements of a list', () => {
+
+  xit('empty list', () => {
+    const list1 = new List();
+    expect(list1.reverse().values).toEqual([]);
+  });
+
+  xit('non-empty list', () => {
+    const list1 = new List([1, 3, 5, 7]);
+    expect(list1.reverse().values).toEqual([7, 5, 3, 1]);
+  });
+
+});

--- a/exercises/list-ops/package.json
+++ b/exercises/list-ops/package.json
@@ -1,0 +1,74 @@
+{
+  "name": "xecmascript",
+  "version": "0.0.0",
+  "description": "Exercism exercises in ECMAScript 6.",
+  "author": "Katrina Owen",
+  "private": true,
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/exercism/xecmascript"
+  },
+  "devDependencies": {
+    "babel-jest": "^20.0.1",
+    "babel-preset-env": "^1.4.0",
+    "babel-plugin-transform-builtin-extend": "^1.1.2",
+    "eslint": "^3.19.0",
+    "jest": "^20.0.1"
+  },
+  "jest": {
+    "modulePathIgnorePatterns": [
+      "package.json"
+    ]
+  },
+  "babel": {
+    "presets": [
+      "env"
+    ],
+    "plugins": [
+      ["babel-plugin-transform-builtin-extend", {
+        "globals": ["Error"]
+      }]
+    ]
+  },
+  "scripts": {
+    "test": "jest --no-cache ./*",
+    "watch": "jest --no-cache --watch ./*",
+    "lint": "eslint .",
+    "lint-test": "eslint . && jest --no-cache ./* "
+  },
+  "eslintConfig": {
+    "parserOptions": {
+      "ecmaVersion": 6,
+      "sourceType": "module"
+    },
+    "env": {
+      "es6": true,
+      "node": true,
+      "jasmine": true
+    },
+    "extends": "eslint:recommended",
+    "rules": {
+      "indent": [ "off", 2 ],
+      "block-scoped-var": "off",
+      "radix": "off",
+      "no-use-before-define": "off",
+      "one-var": [ "off", "always" ],
+      "quotes": [ "off", "single", { "avoidEscape": true } ],
+      "semi": [ "off", "always" ],
+      "semi-spacing": [ "off", { "before": false, "after": true } ],
+      "no-whitespace-before-property": "off",
+      "space-before-blocks": [ "off", "always" ],
+      "space-before-function-paren": [ "off", { "anonymous": "always", "named": "never" } ],
+      "keyword-spacing": [ "off", { "before": true, "after": true } ],
+      "no-multi-spaces": "off",
+      "no-trailing-spaces": "off",
+      "curly": [ "error", "all" ],
+      "brace-style": [ "error", "1tbs", { "allowSingleLine": true } ],
+      "object-curly-spacing": [ "off", "always" ]
+    }
+  },
+  "licenses": [
+    "MIT"
+  ],
+  "dependencies": {}
+}


### PR DESCRIPTION
A few thoughts:

1. I let myself use `pop` and `push`, using arrays to store the data. No Array iterator methods, no `length` property.  I did cheat a little and use the array index for the `foldr` method.  If anyone has any better ideas for this, I'm open.
2. I intentionally didn't mutate the inputs.  If we were handling objects instead of primitives, we might want to copy the objects before adding them to the list.
3. I made `length()` a method rather than a property.  I could be persuaded to change that, but it does mean that the `length` property would have to be updated with every relevant operation, so, it seems nicer to calculate it when needed.
4. Where it made sense, I made the methods chainable.  Some of the tests expect this, but I think that's OK since we're trying to emulate functional iterator methods, so it seems like the right thing to do.

Any feedback would be appreciated!