### PR TITLE
Chose Airbnb style guide as code standard enforced by ESLint

### DIFF
--- a/exercises/accumulate/package.json
+++ b/exercises/accumulate/package.json
@@ -10,9 +10,13 @@
   },
   "devDependencies": {
     "babel-jest": "^20.0.1",
-    "babel-preset-env": "^1.4.0",
     "babel-plugin-transform-builtin-extend": "^1.1.2",
+    "babel-preset-env": "^1.4.0",
     "eslint": "^3.19.0",
+    "eslint-config-airbnb": "^15.0.1",
+    "eslint-plugin-import": "^2.2.0",
+    "eslint-plugin-jsx-a11y": "^5.0.1",
+    "eslint-plugin-react": "^7.0.1",
     "jest": "^20.0.1"
   },
   "jest": {
@@ -49,75 +53,12 @@
     "env": {
       "es6": true,
       "node": true,
-      "jasmine": true
+      "jest": true
     },
-    "extends": "eslint:recommended",
+    "extends": "airbnb",
     "rules": {
-      "indent": [
-        "off",
-        2
-      ],
-      "block-scoped-var": "off",
-      "radix": "off",
-      "no-use-before-define": "off",
-      "one-var": [
-        "off",
-        "always"
-      ],
-      "quotes": [
-        "off",
-        "single",
-        {
-          "avoidEscape": true
-        }
-      ],
-      "semi": [
-        "off",
-        "always"
-      ],
-      "semi-spacing": [
-        "off",
-        {
-          "before": false,
-          "after": true
-        }
-      ],
-      "no-whitespace-before-property": "off",
-      "space-before-blocks": [
-        "off",
-        "always"
-      ],
-      "space-before-function-paren": [
-        "off",
-        {
-          "anonymous": "always",
-          "named": "never"
-        }
-      ],
-      "keyword-spacing": [
-        "off",
-        {
-          "before": true,
-          "after": true
-        }
-      ],
-      "no-multi-spaces": "off",
-      "no-trailing-spaces": "off",
-      "curly": [
-        "error",
-        "all"
-      ],
-      "brace-style": [
-        "error",
-        "1tbs",
-        {
-          "allowSingleLine": true
-        }
-      ],
-      "object-curly-spacing": [
-        "off",
-        "always"
-      ]
+      "import/no-unresolved": "off",
+      "import/extensions": "off"
     }
   },
   "licenses": [
@@ -125,3 +66,4 @@
   ],
   "dependencies": {}
 }
+

--- a/exercises/acronym/package.json
+++ b/exercises/acronym/package.json
@@ -10,9 +10,13 @@
   },
   "devDependencies": {
     "babel-jest": "^20.0.1",
-    "babel-preset-env": "^1.4.0",
     "babel-plugin-transform-builtin-extend": "^1.1.2",
+    "babel-preset-env": "^1.4.0",
     "eslint": "^3.19.0",
+    "eslint-config-airbnb": "^15.0.1",
+    "eslint-plugin-import": "^2.2.0",
+    "eslint-plugin-jsx-a11y": "^5.0.1",
+    "eslint-plugin-react": "^7.0.1",
     "jest": "^20.0.1"
   },
   "jest": {
@@ -49,75 +53,12 @@
     "env": {
       "es6": true,
       "node": true,
-      "jasmine": true
+      "jest": true
     },
-    "extends": "eslint:recommended",
+    "extends": "airbnb",
     "rules": {
-      "indent": [
-        "off",
-        2
-      ],
-      "block-scoped-var": "off",
-      "radix": "off",
-      "no-use-before-define": "off",
-      "one-var": [
-        "off",
-        "always"
-      ],
-      "quotes": [
-        "off",
-        "single",
-        {
-          "avoidEscape": true
-        }
-      ],
-      "semi": [
-        "off",
-        "always"
-      ],
-      "semi-spacing": [
-        "off",
-        {
-          "before": false,
-          "after": true
-        }
-      ],
-      "no-whitespace-before-property": "off",
-      "space-before-blocks": [
-        "off",
-        "always"
-      ],
-      "space-before-function-paren": [
-        "off",
-        {
-          "anonymous": "always",
-          "named": "never"
-        }
-      ],
-      "keyword-spacing": [
-        "off",
-        {
-          "before": true,
-          "after": true
-        }
-      ],
-      "no-multi-spaces": "off",
-      "no-trailing-spaces": "off",
-      "curly": [
-        "error",
-        "all"
-      ],
-      "brace-style": [
-        "error",
-        "1tbs",
-        {
-          "allowSingleLine": true
-        }
-      ],
-      "object-curly-spacing": [
-        "off",
-        "always"
-      ]
+      "import/no-unresolved": "off",
+      "import/extensions": "off"
     }
   },
   "licenses": [
@@ -125,3 +66,4 @@
   ],
   "dependencies": {}
 }
+

--- a/exercises/all-your-base/package.json
+++ b/exercises/all-your-base/package.json
@@ -10,9 +10,13 @@
   },
   "devDependencies": {
     "babel-jest": "^20.0.1",
-    "babel-preset-env": "^1.4.0",
     "babel-plugin-transform-builtin-extend": "^1.1.2",
+    "babel-preset-env": "^1.4.0",
     "eslint": "^3.19.0",
+    "eslint-config-airbnb": "^15.0.1",
+    "eslint-plugin-import": "^2.2.0",
+    "eslint-plugin-jsx-a11y": "^5.0.1",
+    "eslint-plugin-react": "^7.0.1",
     "jest": "^20.0.1"
   },
   "jest": {
@@ -49,75 +53,12 @@
     "env": {
       "es6": true,
       "node": true,
-      "jasmine": true
+      "jest": true
     },
-    "extends": "eslint:recommended",
+    "extends": "airbnb",
     "rules": {
-      "indent": [
-        "off",
-        2
-      ],
-      "block-scoped-var": "off",
-      "radix": "off",
-      "no-use-before-define": "off",
-      "one-var": [
-        "off",
-        "always"
-      ],
-      "quotes": [
-        "off",
-        "single",
-        {
-          "avoidEscape": true
-        }
-      ],
-      "semi": [
-        "off",
-        "always"
-      ],
-      "semi-spacing": [
-        "off",
-        {
-          "before": false,
-          "after": true
-        }
-      ],
-      "no-whitespace-before-property": "off",
-      "space-before-blocks": [
-        "off",
-        "always"
-      ],
-      "space-before-function-paren": [
-        "off",
-        {
-          "anonymous": "always",
-          "named": "never"
-        }
-      ],
-      "keyword-spacing": [
-        "off",
-        {
-          "before": true,
-          "after": true
-        }
-      ],
-      "no-multi-spaces": "off",
-      "no-trailing-spaces": "off",
-      "curly": [
-        "error",
-        "all"
-      ],
-      "brace-style": [
-        "error",
-        "1tbs",
-        {
-          "allowSingleLine": true
-        }
-      ],
-      "object-curly-spacing": [
-        "off",
-        "always"
-      ]
+      "import/no-unresolved": "off",
+      "import/extensions": "off"
     }
   },
   "licenses": [
@@ -125,3 +66,4 @@
   ],
   "dependencies": {}
 }
+

--- a/exercises/allergies/package.json
+++ b/exercises/allergies/package.json
@@ -10,9 +10,13 @@
   },
   "devDependencies": {
     "babel-jest": "^20.0.1",
-    "babel-preset-env": "^1.4.0",
     "babel-plugin-transform-builtin-extend": "^1.1.2",
+    "babel-preset-env": "^1.4.0",
     "eslint": "^3.19.0",
+    "eslint-config-airbnb": "^15.0.1",
+    "eslint-plugin-import": "^2.2.0",
+    "eslint-plugin-jsx-a11y": "^5.0.1",
+    "eslint-plugin-react": "^7.0.1",
     "jest": "^20.0.1"
   },
   "jest": {
@@ -49,75 +53,12 @@
     "env": {
       "es6": true,
       "node": true,
-      "jasmine": true
+      "jest": true
     },
-    "extends": "eslint:recommended",
+    "extends": "airbnb",
     "rules": {
-      "indent": [
-        "off",
-        2
-      ],
-      "block-scoped-var": "off",
-      "radix": "off",
-      "no-use-before-define": "off",
-      "one-var": [
-        "off",
-        "always"
-      ],
-      "quotes": [
-        "off",
-        "single",
-        {
-          "avoidEscape": true
-        }
-      ],
-      "semi": [
-        "off",
-        "always"
-      ],
-      "semi-spacing": [
-        "off",
-        {
-          "before": false,
-          "after": true
-        }
-      ],
-      "no-whitespace-before-property": "off",
-      "space-before-blocks": [
-        "off",
-        "always"
-      ],
-      "space-before-function-paren": [
-        "off",
-        {
-          "anonymous": "always",
-          "named": "never"
-        }
-      ],
-      "keyword-spacing": [
-        "off",
-        {
-          "before": true,
-          "after": true
-        }
-      ],
-      "no-multi-spaces": "off",
-      "no-trailing-spaces": "off",
-      "curly": [
-        "error",
-        "all"
-      ],
-      "brace-style": [
-        "error",
-        "1tbs",
-        {
-          "allowSingleLine": true
-        }
-      ],
-      "object-curly-spacing": [
-        "off",
-        "always"
-      ]
+      "import/no-unresolved": "off",
+      "import/extensions": "off"
     }
   },
   "licenses": [
@@ -125,3 +66,4 @@
   ],
   "dependencies": {}
 }
+

--- a/exercises/alphametics/package.json
+++ b/exercises/alphametics/package.json
@@ -10,9 +10,13 @@
   },
   "devDependencies": {
     "babel-jest": "^20.0.1",
-    "babel-preset-env": "^1.4.0",
     "babel-plugin-transform-builtin-extend": "^1.1.2",
+    "babel-preset-env": "^1.4.0",
     "eslint": "^3.19.0",
+    "eslint-config-airbnb": "^15.0.1",
+    "eslint-plugin-import": "^2.2.0",
+    "eslint-plugin-jsx-a11y": "^5.0.1",
+    "eslint-plugin-react": "^7.0.1",
     "jest": "^20.0.1"
   },
   "jest": {
@@ -49,75 +53,12 @@
     "env": {
       "es6": true,
       "node": true,
-      "jasmine": true
+      "jest": true
     },
-    "extends": "eslint:recommended",
+    "extends": "airbnb",
     "rules": {
-      "indent": [
-        "off",
-        2
-      ],
-      "block-scoped-var": "off",
-      "radix": "off",
-      "no-use-before-define": "off",
-      "one-var": [
-        "off",
-        "always"
-      ],
-      "quotes": [
-        "off",
-        "single",
-        {
-          "avoidEscape": true
-        }
-      ],
-      "semi": [
-        "off",
-        "always"
-      ],
-      "semi-spacing": [
-        "off",
-        {
-          "before": false,
-          "after": true
-        }
-      ],
-      "no-whitespace-before-property": "off",
-      "space-before-blocks": [
-        "off",
-        "always"
-      ],
-      "space-before-function-paren": [
-        "off",
-        {
-          "anonymous": "always",
-          "named": "never"
-        }
-      ],
-      "keyword-spacing": [
-        "off",
-        {
-          "before": true,
-          "after": true
-        }
-      ],
-      "no-multi-spaces": "off",
-      "no-trailing-spaces": "off",
-      "curly": [
-        "error",
-        "all"
-      ],
-      "brace-style": [
-        "error",
-        "1tbs",
-        {
-          "allowSingleLine": true
-        }
-      ],
-      "object-curly-spacing": [
-        "off",
-        "always"
-      ]
+      "import/no-unresolved": "off",
+      "import/extensions": "off"
     }
   },
   "licenses": [
@@ -125,3 +66,4 @@
   ],
   "dependencies": {}
 }
+

--- a/exercises/anagram/package.json
+++ b/exercises/anagram/package.json
@@ -10,9 +10,13 @@
   },
   "devDependencies": {
     "babel-jest": "^20.0.1",
-    "babel-preset-env": "^1.4.0",
     "babel-plugin-transform-builtin-extend": "^1.1.2",
+    "babel-preset-env": "^1.4.0",
     "eslint": "^3.19.0",
+    "eslint-config-airbnb": "^15.0.1",
+    "eslint-plugin-import": "^2.2.0",
+    "eslint-plugin-jsx-a11y": "^5.0.1",
+    "eslint-plugin-react": "^7.0.1",
     "jest": "^20.0.1"
   },
   "jest": {
@@ -49,75 +53,12 @@
     "env": {
       "es6": true,
       "node": true,
-      "jasmine": true
+      "jest": true
     },
-    "extends": "eslint:recommended",
+    "extends": "airbnb",
     "rules": {
-      "indent": [
-        "off",
-        2
-      ],
-      "block-scoped-var": "off",
-      "radix": "off",
-      "no-use-before-define": "off",
-      "one-var": [
-        "off",
-        "always"
-      ],
-      "quotes": [
-        "off",
-        "single",
-        {
-          "avoidEscape": true
-        }
-      ],
-      "semi": [
-        "off",
-        "always"
-      ],
-      "semi-spacing": [
-        "off",
-        {
-          "before": false,
-          "after": true
-        }
-      ],
-      "no-whitespace-before-property": "off",
-      "space-before-blocks": [
-        "off",
-        "always"
-      ],
-      "space-before-function-paren": [
-        "off",
-        {
-          "anonymous": "always",
-          "named": "never"
-        }
-      ],
-      "keyword-spacing": [
-        "off",
-        {
-          "before": true,
-          "after": true
-        }
-      ],
-      "no-multi-spaces": "off",
-      "no-trailing-spaces": "off",
-      "curly": [
-        "error",
-        "all"
-      ],
-      "brace-style": [
-        "error",
-        "1tbs",
-        {
-          "allowSingleLine": true
-        }
-      ],
-      "object-curly-spacing": [
-        "off",
-        "always"
-      ]
+      "import/no-unresolved": "off",
+      "import/extensions": "off"
     }
   },
   "licenses": [
@@ -125,3 +66,4 @@
   ],
   "dependencies": {}
 }
+

--- a/exercises/atbash-cipher/package.json
+++ b/exercises/atbash-cipher/package.json
@@ -10,9 +10,13 @@
   },
   "devDependencies": {
     "babel-jest": "^20.0.1",
-    "babel-preset-env": "^1.4.0",
     "babel-plugin-transform-builtin-extend": "^1.1.2",
+    "babel-preset-env": "^1.4.0",
     "eslint": "^3.19.0",
+    "eslint-config-airbnb": "^15.0.1",
+    "eslint-plugin-import": "^2.2.0",
+    "eslint-plugin-jsx-a11y": "^5.0.1",
+    "eslint-plugin-react": "^7.0.1",
     "jest": "^20.0.1"
   },
   "jest": {
@@ -49,75 +53,12 @@
     "env": {
       "es6": true,
       "node": true,
-      "jasmine": true
+      "jest": true
     },
-    "extends": "eslint:recommended",
+    "extends": "airbnb",
     "rules": {
-      "indent": [
-        "off",
-        2
-      ],
-      "block-scoped-var": "off",
-      "radix": "off",
-      "no-use-before-define": "off",
-      "one-var": [
-        "off",
-        "always"
-      ],
-      "quotes": [
-        "off",
-        "single",
-        {
-          "avoidEscape": true
-        }
-      ],
-      "semi": [
-        "off",
-        "always"
-      ],
-      "semi-spacing": [
-        "off",
-        {
-          "before": false,
-          "after": true
-        }
-      ],
-      "no-whitespace-before-property": "off",
-      "space-before-blocks": [
-        "off",
-        "always"
-      ],
-      "space-before-function-paren": [
-        "off",
-        {
-          "anonymous": "always",
-          "named": "never"
-        }
-      ],
-      "keyword-spacing": [
-        "off",
-        {
-          "before": true,
-          "after": true
-        }
-      ],
-      "no-multi-spaces": "off",
-      "no-trailing-spaces": "off",
-      "curly": [
-        "error",
-        "all"
-      ],
-      "brace-style": [
-        "error",
-        "1tbs",
-        {
-          "allowSingleLine": true
-        }
-      ],
-      "object-curly-spacing": [
-        "off",
-        "always"
-      ]
+      "import/no-unresolved": "off",
+      "import/extensions": "off"
     }
   },
   "licenses": [
@@ -125,3 +66,4 @@
   ],
   "dependencies": {}
 }
+

--- a/exercises/beer-song/package.json
+++ b/exercises/beer-song/package.json
@@ -10,9 +10,13 @@
   },
   "devDependencies": {
     "babel-jest": "^20.0.1",
-    "babel-preset-env": "^1.4.0",
     "babel-plugin-transform-builtin-extend": "^1.1.2",
+    "babel-preset-env": "^1.4.0",
     "eslint": "^3.19.0",
+    "eslint-config-airbnb": "^15.0.1",
+    "eslint-plugin-import": "^2.2.0",
+    "eslint-plugin-jsx-a11y": "^5.0.1",
+    "eslint-plugin-react": "^7.0.1",
     "jest": "^20.0.1"
   },
   "jest": {
@@ -49,75 +53,12 @@
     "env": {
       "es6": true,
       "node": true,
-      "jasmine": true
+      "jest": true
     },
-    "extends": "eslint:recommended",
+    "extends": "airbnb",
     "rules": {
-      "indent": [
-        "off",
-        2
-      ],
-      "block-scoped-var": "off",
-      "radix": "off",
-      "no-use-before-define": "off",
-      "one-var": [
-        "off",
-        "always"
-      ],
-      "quotes": [
-        "off",
-        "single",
-        {
-          "avoidEscape": true
-        }
-      ],
-      "semi": [
-        "off",
-        "always"
-      ],
-      "semi-spacing": [
-        "off",
-        {
-          "before": false,
-          "after": true
-        }
-      ],
-      "no-whitespace-before-property": "off",
-      "space-before-blocks": [
-        "off",
-        "always"
-      ],
-      "space-before-function-paren": [
-        "off",
-        {
-          "anonymous": "always",
-          "named": "never"
-        }
-      ],
-      "keyword-spacing": [
-        "off",
-        {
-          "before": true,
-          "after": true
-        }
-      ],
-      "no-multi-spaces": "off",
-      "no-trailing-spaces": "off",
-      "curly": [
-        "error",
-        "all"
-      ],
-      "brace-style": [
-        "error",
-        "1tbs",
-        {
-          "allowSingleLine": true
-        }
-      ],
-      "object-curly-spacing": [
-        "off",
-        "always"
-      ]
+      "import/no-unresolved": "off",
+      "import/extensions": "off"
     }
   },
   "licenses": [
@@ -125,3 +66,4 @@
   ],
   "dependencies": {}
 }
+

--- a/exercises/binary-search-tree/package.json
+++ b/exercises/binary-search-tree/package.json
@@ -10,9 +10,13 @@
   },
   "devDependencies": {
     "babel-jest": "^20.0.1",
-    "babel-preset-env": "^1.4.0",
     "babel-plugin-transform-builtin-extend": "^1.1.2",
+    "babel-preset-env": "^1.4.0",
     "eslint": "^3.19.0",
+    "eslint-config-airbnb": "^15.0.1",
+    "eslint-plugin-import": "^2.2.0",
+    "eslint-plugin-jsx-a11y": "^5.0.1",
+    "eslint-plugin-react": "^7.0.1",
     "jest": "^20.0.1"
   },
   "jest": {
@@ -49,75 +53,12 @@
     "env": {
       "es6": true,
       "node": true,
-      "jasmine": true
+      "jest": true
     },
-    "extends": "eslint:recommended",
+    "extends": "airbnb",
     "rules": {
-      "indent": [
-        "off",
-        2
-      ],
-      "block-scoped-var": "off",
-      "radix": "off",
-      "no-use-before-define": "off",
-      "one-var": [
-        "off",
-        "always"
-      ],
-      "quotes": [
-        "off",
-        "single",
-        {
-          "avoidEscape": true
-        }
-      ],
-      "semi": [
-        "off",
-        "always"
-      ],
-      "semi-spacing": [
-        "off",
-        {
-          "before": false,
-          "after": true
-        }
-      ],
-      "no-whitespace-before-property": "off",
-      "space-before-blocks": [
-        "off",
-        "always"
-      ],
-      "space-before-function-paren": [
-        "off",
-        {
-          "anonymous": "always",
-          "named": "never"
-        }
-      ],
-      "keyword-spacing": [
-        "off",
-        {
-          "before": true,
-          "after": true
-        }
-      ],
-      "no-multi-spaces": "off",
-      "no-trailing-spaces": "off",
-      "curly": [
-        "error",
-        "all"
-      ],
-      "brace-style": [
-        "error",
-        "1tbs",
-        {
-          "allowSingleLine": true
-        }
-      ],
-      "object-curly-spacing": [
-        "off",
-        "always"
-      ]
+      "import/no-unresolved": "off",
+      "import/extensions": "off"
     }
   },
   "licenses": [
@@ -125,3 +66,4 @@
   ],
   "dependencies": {}
 }
+

--- a/exercises/binary-search/package.json
+++ b/exercises/binary-search/package.json
@@ -10,9 +10,13 @@
   },
   "devDependencies": {
     "babel-jest": "^20.0.1",
-    "babel-preset-env": "^1.4.0",
     "babel-plugin-transform-builtin-extend": "^1.1.2",
+    "babel-preset-env": "^1.4.0",
     "eslint": "^3.19.0",
+    "eslint-config-airbnb": "^15.0.1",
+    "eslint-plugin-import": "^2.2.0",
+    "eslint-plugin-jsx-a11y": "^5.0.1",
+    "eslint-plugin-react": "^7.0.1",
     "jest": "^20.0.1"
   },
   "jest": {
@@ -49,75 +53,12 @@
     "env": {
       "es6": true,
       "node": true,
-      "jasmine": true
+      "jest": true
     },
-    "extends": "eslint:recommended",
+    "extends": "airbnb",
     "rules": {
-      "indent": [
-        "off",
-        2
-      ],
-      "block-scoped-var": "off",
-      "radix": "off",
-      "no-use-before-define": "off",
-      "one-var": [
-        "off",
-        "always"
-      ],
-      "quotes": [
-        "off",
-        "single",
-        {
-          "avoidEscape": true
-        }
-      ],
-      "semi": [
-        "off",
-        "always"
-      ],
-      "semi-spacing": [
-        "off",
-        {
-          "before": false,
-          "after": true
-        }
-      ],
-      "no-whitespace-before-property": "off",
-      "space-before-blocks": [
-        "off",
-        "always"
-      ],
-      "space-before-function-paren": [
-        "off",
-        {
-          "anonymous": "always",
-          "named": "never"
-        }
-      ],
-      "keyword-spacing": [
-        "off",
-        {
-          "before": true,
-          "after": true
-        }
-      ],
-      "no-multi-spaces": "off",
-      "no-trailing-spaces": "off",
-      "curly": [
-        "error",
-        "all"
-      ],
-      "brace-style": [
-        "error",
-        "1tbs",
-        {
-          "allowSingleLine": true
-        }
-      ],
-      "object-curly-spacing": [
-        "off",
-        "always"
-      ]
+      "import/no-unresolved": "off",
+      "import/extensions": "off"
     }
   },
   "licenses": [
@@ -125,3 +66,4 @@
   ],
   "dependencies": {}
 }
+

--- a/exercises/binary/package.json
+++ b/exercises/binary/package.json
@@ -10,9 +10,13 @@
   },
   "devDependencies": {
     "babel-jest": "^20.0.1",
-    "babel-preset-env": "^1.4.0",
     "babel-plugin-transform-builtin-extend": "^1.1.2",
+    "babel-preset-env": "^1.4.0",
     "eslint": "^3.19.0",
+    "eslint-config-airbnb": "^15.0.1",
+    "eslint-plugin-import": "^2.2.0",
+    "eslint-plugin-jsx-a11y": "^5.0.1",
+    "eslint-plugin-react": "^7.0.1",
     "jest": "^20.0.1"
   },
   "jest": {
@@ -49,75 +53,12 @@
     "env": {
       "es6": true,
       "node": true,
-      "jasmine": true
+      "jest": true
     },
-    "extends": "eslint:recommended",
+    "extends": "airbnb",
     "rules": {
-      "indent": [
-        "off",
-        2
-      ],
-      "block-scoped-var": "off",
-      "radix": "off",
-      "no-use-before-define": "off",
-      "one-var": [
-        "off",
-        "always"
-      ],
-      "quotes": [
-        "off",
-        "single",
-        {
-          "avoidEscape": true
-        }
-      ],
-      "semi": [
-        "off",
-        "always"
-      ],
-      "semi-spacing": [
-        "off",
-        {
-          "before": false,
-          "after": true
-        }
-      ],
-      "no-whitespace-before-property": "off",
-      "space-before-blocks": [
-        "off",
-        "always"
-      ],
-      "space-before-function-paren": [
-        "off",
-        {
-          "anonymous": "always",
-          "named": "never"
-        }
-      ],
-      "keyword-spacing": [
-        "off",
-        {
-          "before": true,
-          "after": true
-        }
-      ],
-      "no-multi-spaces": "off",
-      "no-trailing-spaces": "off",
-      "curly": [
-        "error",
-        "all"
-      ],
-      "brace-style": [
-        "error",
-        "1tbs",
-        {
-          "allowSingleLine": true
-        }
-      ],
-      "object-curly-spacing": [
-        "off",
-        "always"
-      ]
+      "import/no-unresolved": "off",
+      "import/extensions": "off"
     }
   },
   "licenses": [
@@ -125,3 +66,4 @@
   ],
   "dependencies": {}
 }
+

--- a/exercises/bob/package.json
+++ b/exercises/bob/package.json
@@ -10,9 +10,13 @@
   },
   "devDependencies": {
     "babel-jest": "^20.0.1",
-    "babel-preset-env": "^1.4.0",
     "babel-plugin-transform-builtin-extend": "^1.1.2",
+    "babel-preset-env": "^1.4.0",
     "eslint": "^3.19.0",
+    "eslint-config-airbnb": "^15.0.1",
+    "eslint-plugin-import": "^2.2.0",
+    "eslint-plugin-jsx-a11y": "^5.0.1",
+    "eslint-plugin-react": "^7.0.1",
     "jest": "^20.0.1"
   },
   "jest": {
@@ -49,75 +53,12 @@
     "env": {
       "es6": true,
       "node": true,
-      "jasmine": true
+      "jest": true
     },
-    "extends": "eslint:recommended",
+    "extends": "airbnb",
     "rules": {
-      "indent": [
-        "off",
-        2
-      ],
-      "block-scoped-var": "off",
-      "radix": "off",
-      "no-use-before-define": "off",
-      "one-var": [
-        "off",
-        "always"
-      ],
-      "quotes": [
-        "off",
-        "single",
-        {
-          "avoidEscape": true
-        }
-      ],
-      "semi": [
-        "off",
-        "always"
-      ],
-      "semi-spacing": [
-        "off",
-        {
-          "before": false,
-          "after": true
-        }
-      ],
-      "no-whitespace-before-property": "off",
-      "space-before-blocks": [
-        "off",
-        "always"
-      ],
-      "space-before-function-paren": [
-        "off",
-        {
-          "anonymous": "always",
-          "named": "never"
-        }
-      ],
-      "keyword-spacing": [
-        "off",
-        {
-          "before": true,
-          "after": true
-        }
-      ],
-      "no-multi-spaces": "off",
-      "no-trailing-spaces": "off",
-      "curly": [
-        "error",
-        "all"
-      ],
-      "brace-style": [
-        "error",
-        "1tbs",
-        {
-          "allowSingleLine": true
-        }
-      ],
-      "object-curly-spacing": [
-        "off",
-        "always"
-      ]
+      "import/no-unresolved": "off",
+      "import/extensions": "off"
     }
   },
   "licenses": [
@@ -125,3 +66,4 @@
   ],
   "dependencies": {}
 }
+

--- a/exercises/bracket-push/package.json
+++ b/exercises/bracket-push/package.json
@@ -10,9 +10,13 @@
   },
   "devDependencies": {
     "babel-jest": "^20.0.1",
-    "babel-preset-env": "^1.4.0",
     "babel-plugin-transform-builtin-extend": "^1.1.2",
+    "babel-preset-env": "^1.4.0",
     "eslint": "^3.19.0",
+    "eslint-config-airbnb": "^15.0.1",
+    "eslint-plugin-import": "^2.2.0",
+    "eslint-plugin-jsx-a11y": "^5.0.1",
+    "eslint-plugin-react": "^7.0.1",
     "jest": "^20.0.1"
   },
   "jest": {
@@ -49,75 +53,12 @@
     "env": {
       "es6": true,
       "node": true,
-      "jasmine": true
+      "jest": true
     },
-    "extends": "eslint:recommended",
+    "extends": "airbnb",
     "rules": {
-      "indent": [
-        "off",
-        2
-      ],
-      "block-scoped-var": "off",
-      "radix": "off",
-      "no-use-before-define": "off",
-      "one-var": [
-        "off",
-        "always"
-      ],
-      "quotes": [
-        "off",
-        "single",
-        {
-          "avoidEscape": true
-        }
-      ],
-      "semi": [
-        "off",
-        "always"
-      ],
-      "semi-spacing": [
-        "off",
-        {
-          "before": false,
-          "after": true
-        }
-      ],
-      "no-whitespace-before-property": "off",
-      "space-before-blocks": [
-        "off",
-        "always"
-      ],
-      "space-before-function-paren": [
-        "off",
-        {
-          "anonymous": "always",
-          "named": "never"
-        }
-      ],
-      "keyword-spacing": [
-        "off",
-        {
-          "before": true,
-          "after": true
-        }
-      ],
-      "no-multi-spaces": "off",
-      "no-trailing-spaces": "off",
-      "curly": [
-        "error",
-        "all"
-      ],
-      "brace-style": [
-        "error",
-        "1tbs",
-        {
-          "allowSingleLine": true
-        }
-      ],
-      "object-curly-spacing": [
-        "off",
-        "always"
-      ]
+      "import/no-unresolved": "off",
+      "import/extensions": "off"
     }
   },
   "licenses": [
@@ -125,3 +66,4 @@
   ],
   "dependencies": {}
 }
+

--- a/exercises/circular-buffer/package.json
+++ b/exercises/circular-buffer/package.json
@@ -10,9 +10,13 @@
   },
   "devDependencies": {
     "babel-jest": "^20.0.1",
-    "babel-preset-env": "^1.4.0",
     "babel-plugin-transform-builtin-extend": "^1.1.2",
+    "babel-preset-env": "^1.4.0",
     "eslint": "^3.19.0",
+    "eslint-config-airbnb": "^15.0.1",
+    "eslint-plugin-import": "^2.2.0",
+    "eslint-plugin-jsx-a11y": "^5.0.1",
+    "eslint-plugin-react": "^7.0.1",
     "jest": "^20.0.1"
   },
   "jest": {
@@ -49,75 +53,12 @@
     "env": {
       "es6": true,
       "node": true,
-      "jasmine": true
+      "jest": true
     },
-    "extends": "eslint:recommended",
+    "extends": "airbnb",
     "rules": {
-      "indent": [
-        "off",
-        2
-      ],
-      "block-scoped-var": "off",
-      "radix": "off",
-      "no-use-before-define": "off",
-      "one-var": [
-        "off",
-        "always"
-      ],
-      "quotes": [
-        "off",
-        "single",
-        {
-          "avoidEscape": true
-        }
-      ],
-      "semi": [
-        "off",
-        "always"
-      ],
-      "semi-spacing": [
-        "off",
-        {
-          "before": false,
-          "after": true
-        }
-      ],
-      "no-whitespace-before-property": "off",
-      "space-before-blocks": [
-        "off",
-        "always"
-      ],
-      "space-before-function-paren": [
-        "off",
-        {
-          "anonymous": "always",
-          "named": "never"
-        }
-      ],
-      "keyword-spacing": [
-        "off",
-        {
-          "before": true,
-          "after": true
-        }
-      ],
-      "no-multi-spaces": "off",
-      "no-trailing-spaces": "off",
-      "curly": [
-        "error",
-        "all"
-      ],
-      "brace-style": [
-        "error",
-        "1tbs",
-        {
-          "allowSingleLine": true
-        }
-      ],
-      "object-curly-spacing": [
-        "off",
-        "always"
-      ]
+      "import/no-unresolved": "off",
+      "import/extensions": "off"
     }
   },
   "licenses": [
@@ -125,3 +66,4 @@
   ],
   "dependencies": {}
 }
+

--- a/exercises/clock/package.json
+++ b/exercises/clock/package.json
@@ -10,9 +10,13 @@
   },
   "devDependencies": {
     "babel-jest": "^20.0.1",
-    "babel-preset-env": "^1.4.0",
     "babel-plugin-transform-builtin-extend": "^1.1.2",
+    "babel-preset-env": "^1.4.0",
     "eslint": "^3.19.0",
+    "eslint-config-airbnb": "^15.0.1",
+    "eslint-plugin-import": "^2.2.0",
+    "eslint-plugin-jsx-a11y": "^5.0.1",
+    "eslint-plugin-react": "^7.0.1",
     "jest": "^20.0.1"
   },
   "jest": {
@@ -49,75 +53,12 @@
     "env": {
       "es6": true,
       "node": true,
-      "jasmine": true
+      "jest": true
     },
-    "extends": "eslint:recommended",
+    "extends": "airbnb",
     "rules": {
-      "indent": [
-        "off",
-        2
-      ],
-      "block-scoped-var": "off",
-      "radix": "off",
-      "no-use-before-define": "off",
-      "one-var": [
-        "off",
-        "always"
-      ],
-      "quotes": [
-        "off",
-        "single",
-        {
-          "avoidEscape": true
-        }
-      ],
-      "semi": [
-        "off",
-        "always"
-      ],
-      "semi-spacing": [
-        "off",
-        {
-          "before": false,
-          "after": true
-        }
-      ],
-      "no-whitespace-before-property": "off",
-      "space-before-blocks": [
-        "off",
-        "always"
-      ],
-      "space-before-function-paren": [
-        "off",
-        {
-          "anonymous": "always",
-          "named": "never"
-        }
-      ],
-      "keyword-spacing": [
-        "off",
-        {
-          "before": true,
-          "after": true
-        }
-      ],
-      "no-multi-spaces": "off",
-      "no-trailing-spaces": "off",
-      "curly": [
-        "error",
-        "all"
-      ],
-      "brace-style": [
-        "error",
-        "1tbs",
-        {
-          "allowSingleLine": true
-        }
-      ],
-      "object-curly-spacing": [
-        "off",
-        "always"
-      ]
+      "import/no-unresolved": "off",
+      "import/extensions": "off"
     }
   },
   "licenses": [
@@ -125,3 +66,4 @@
   ],
   "dependencies": {}
 }
+

--- a/exercises/connect/package.json
+++ b/exercises/connect/package.json
@@ -10,9 +10,13 @@
   },
   "devDependencies": {
     "babel-jest": "^20.0.1",
-    "babel-preset-env": "^1.4.0",
     "babel-plugin-transform-builtin-extend": "^1.1.2",
+    "babel-preset-env": "^1.4.0",
     "eslint": "^3.19.0",
+    "eslint-config-airbnb": "^15.0.1",
+    "eslint-plugin-import": "^2.2.0",
+    "eslint-plugin-jsx-a11y": "^5.0.1",
+    "eslint-plugin-react": "^7.0.1",
     "jest": "^20.0.1"
   },
   "jest": {
@@ -49,75 +53,12 @@
     "env": {
       "es6": true,
       "node": true,
-      "jasmine": true
+      "jest": true
     },
-    "extends": "eslint:recommended",
+    "extends": "airbnb",
     "rules": {
-      "indent": [
-        "off",
-        2
-      ],
-      "block-scoped-var": "off",
-      "radix": "off",
-      "no-use-before-define": "off",
-      "one-var": [
-        "off",
-        "always"
-      ],
-      "quotes": [
-        "off",
-        "single",
-        {
-          "avoidEscape": true
-        }
-      ],
-      "semi": [
-        "off",
-        "always"
-      ],
-      "semi-spacing": [
-        "off",
-        {
-          "before": false,
-          "after": true
-        }
-      ],
-      "no-whitespace-before-property": "off",
-      "space-before-blocks": [
-        "off",
-        "always"
-      ],
-      "space-before-function-paren": [
-        "off",
-        {
-          "anonymous": "always",
-          "named": "never"
-        }
-      ],
-      "keyword-spacing": [
-        "off",
-        {
-          "before": true,
-          "after": true
-        }
-      ],
-      "no-multi-spaces": "off",
-      "no-trailing-spaces": "off",
-      "curly": [
-        "error",
-        "all"
-      ],
-      "brace-style": [
-        "error",
-        "1tbs",
-        {
-          "allowSingleLine": true
-        }
-      ],
-      "object-curly-spacing": [
-        "off",
-        "always"
-      ]
+      "import/no-unresolved": "off",
+      "import/extensions": "off"
     }
   },
   "licenses": [
@@ -125,3 +66,4 @@
   ],
   "dependencies": {}
 }
+

--- a/exercises/crypto-square/package.json
+++ b/exercises/crypto-square/package.json
@@ -10,9 +10,13 @@
   },
   "devDependencies": {
     "babel-jest": "^20.0.1",
-    "babel-preset-env": "^1.4.0",
     "babel-plugin-transform-builtin-extend": "^1.1.2",
+    "babel-preset-env": "^1.4.0",
     "eslint": "^3.19.0",
+    "eslint-config-airbnb": "^15.0.1",
+    "eslint-plugin-import": "^2.2.0",
+    "eslint-plugin-jsx-a11y": "^5.0.1",
+    "eslint-plugin-react": "^7.0.1",
     "jest": "^20.0.1"
   },
   "jest": {
@@ -49,75 +53,12 @@
     "env": {
       "es6": true,
       "node": true,
-      "jasmine": true
+      "jest": true
     },
-    "extends": "eslint:recommended",
+    "extends": "airbnb",
     "rules": {
-      "indent": [
-        "off",
-        2
-      ],
-      "block-scoped-var": "off",
-      "radix": "off",
-      "no-use-before-define": "off",
-      "one-var": [
-        "off",
-        "always"
-      ],
-      "quotes": [
-        "off",
-        "single",
-        {
-          "avoidEscape": true
-        }
-      ],
-      "semi": [
-        "off",
-        "always"
-      ],
-      "semi-spacing": [
-        "off",
-        {
-          "before": false,
-          "after": true
-        }
-      ],
-      "no-whitespace-before-property": "off",
-      "space-before-blocks": [
-        "off",
-        "always"
-      ],
-      "space-before-function-paren": [
-        "off",
-        {
-          "anonymous": "always",
-          "named": "never"
-        }
-      ],
-      "keyword-spacing": [
-        "off",
-        {
-          "before": true,
-          "after": true
-        }
-      ],
-      "no-multi-spaces": "off",
-      "no-trailing-spaces": "off",
-      "curly": [
-        "error",
-        "all"
-      ],
-      "brace-style": [
-        "error",
-        "1tbs",
-        {
-          "allowSingleLine": true
-        }
-      ],
-      "object-curly-spacing": [
-        "off",
-        "always"
-      ]
+      "import/no-unresolved": "off",
+      "import/extensions": "off"
     }
   },
   "licenses": [
@@ -125,3 +66,4 @@
   ],
   "dependencies": {}
 }
+

--- a/exercises/custom-set/package.json
+++ b/exercises/custom-set/package.json
@@ -10,9 +10,13 @@
   },
   "devDependencies": {
     "babel-jest": "^20.0.1",
-    "babel-preset-env": "^1.4.0",
     "babel-plugin-transform-builtin-extend": "^1.1.2",
+    "babel-preset-env": "^1.4.0",
     "eslint": "^3.19.0",
+    "eslint-config-airbnb": "^15.0.1",
+    "eslint-plugin-import": "^2.2.0",
+    "eslint-plugin-jsx-a11y": "^5.0.1",
+    "eslint-plugin-react": "^7.0.1",
     "jest": "^20.0.1"
   },
   "jest": {
@@ -49,75 +53,12 @@
     "env": {
       "es6": true,
       "node": true,
-      "jasmine": true
+      "jest": true
     },
-    "extends": "eslint:recommended",
+    "extends": "airbnb",
     "rules": {
-      "indent": [
-        "off",
-        2
-      ],
-      "block-scoped-var": "off",
-      "radix": "off",
-      "no-use-before-define": "off",
-      "one-var": [
-        "off",
-        "always"
-      ],
-      "quotes": [
-        "off",
-        "single",
-        {
-          "avoidEscape": true
-        }
-      ],
-      "semi": [
-        "off",
-        "always"
-      ],
-      "semi-spacing": [
-        "off",
-        {
-          "before": false,
-          "after": true
-        }
-      ],
-      "no-whitespace-before-property": "off",
-      "space-before-blocks": [
-        "off",
-        "always"
-      ],
-      "space-before-function-paren": [
-        "off",
-        {
-          "anonymous": "always",
-          "named": "never"
-        }
-      ],
-      "keyword-spacing": [
-        "off",
-        {
-          "before": true,
-          "after": true
-        }
-      ],
-      "no-multi-spaces": "off",
-      "no-trailing-spaces": "off",
-      "curly": [
-        "error",
-        "all"
-      ],
-      "brace-style": [
-        "error",
-        "1tbs",
-        {
-          "allowSingleLine": true
-        }
-      ],
-      "object-curly-spacing": [
-        "off",
-        "always"
-      ]
+      "import/no-unresolved": "off",
+      "import/extensions": "off"
     }
   },
   "licenses": [
@@ -125,3 +66,4 @@
   ],
   "dependencies": {}
 }
+

--- a/exercises/diamond/package.json
+++ b/exercises/diamond/package.json
@@ -10,9 +10,13 @@
   },
   "devDependencies": {
     "babel-jest": "^20.0.1",
-    "babel-preset-env": "^1.4.0",
     "babel-plugin-transform-builtin-extend": "^1.1.2",
+    "babel-preset-env": "^1.4.0",
     "eslint": "^3.19.0",
+    "eslint-config-airbnb": "^15.0.1",
+    "eslint-plugin-import": "^2.2.0",
+    "eslint-plugin-jsx-a11y": "^5.0.1",
+    "eslint-plugin-react": "^7.0.1",
     "jest": "^20.0.1"
   },
   "jest": {
@@ -49,75 +53,12 @@
     "env": {
       "es6": true,
       "node": true,
-      "jasmine": true
+      "jest": true
     },
-    "extends": "eslint:recommended",
+    "extends": "airbnb",
     "rules": {
-      "indent": [
-        "off",
-        2
-      ],
-      "block-scoped-var": "off",
-      "radix": "off",
-      "no-use-before-define": "off",
-      "one-var": [
-        "off",
-        "always"
-      ],
-      "quotes": [
-        "off",
-        "single",
-        {
-          "avoidEscape": true
-        }
-      ],
-      "semi": [
-        "off",
-        "always"
-      ],
-      "semi-spacing": [
-        "off",
-        {
-          "before": false,
-          "after": true
-        }
-      ],
-      "no-whitespace-before-property": "off",
-      "space-before-blocks": [
-        "off",
-        "always"
-      ],
-      "space-before-function-paren": [
-        "off",
-        {
-          "anonymous": "always",
-          "named": "never"
-        }
-      ],
-      "keyword-spacing": [
-        "off",
-        {
-          "before": true,
-          "after": true
-        }
-      ],
-      "no-multi-spaces": "off",
-      "no-trailing-spaces": "off",
-      "curly": [
-        "error",
-        "all"
-      ],
-      "brace-style": [
-        "error",
-        "1tbs",
-        {
-          "allowSingleLine": true
-        }
-      ],
-      "object-curly-spacing": [
-        "off",
-        "always"
-      ]
+      "import/no-unresolved": "off",
+      "import/extensions": "off"
     }
   },
   "licenses": [
@@ -125,3 +66,4 @@
   ],
   "dependencies": {}
 }
+

--- a/exercises/difference-of-squares/package.json
+++ b/exercises/difference-of-squares/package.json
@@ -10,9 +10,13 @@
   },
   "devDependencies": {
     "babel-jest": "^20.0.1",
-    "babel-preset-env": "^1.4.0",
     "babel-plugin-transform-builtin-extend": "^1.1.2",
+    "babel-preset-env": "^1.4.0",
     "eslint": "^3.19.0",
+    "eslint-config-airbnb": "^15.0.1",
+    "eslint-plugin-import": "^2.2.0",
+    "eslint-plugin-jsx-a11y": "^5.0.1",
+    "eslint-plugin-react": "^7.0.1",
     "jest": "^20.0.1"
   },
   "jest": {
@@ -49,75 +53,12 @@
     "env": {
       "es6": true,
       "node": true,
-      "jasmine": true
+      "jest": true
     },
-    "extends": "eslint:recommended",
+    "extends": "airbnb",
     "rules": {
-      "indent": [
-        "off",
-        2
-      ],
-      "block-scoped-var": "off",
-      "radix": "off",
-      "no-use-before-define": "off",
-      "one-var": [
-        "off",
-        "always"
-      ],
-      "quotes": [
-        "off",
-        "single",
-        {
-          "avoidEscape": true
-        }
-      ],
-      "semi": [
-        "off",
-        "always"
-      ],
-      "semi-spacing": [
-        "off",
-        {
-          "before": false,
-          "after": true
-        }
-      ],
-      "no-whitespace-before-property": "off",
-      "space-before-blocks": [
-        "off",
-        "always"
-      ],
-      "space-before-function-paren": [
-        "off",
-        {
-          "anonymous": "always",
-          "named": "never"
-        }
-      ],
-      "keyword-spacing": [
-        "off",
-        {
-          "before": true,
-          "after": true
-        }
-      ],
-      "no-multi-spaces": "off",
-      "no-trailing-spaces": "off",
-      "curly": [
-        "error",
-        "all"
-      ],
-      "brace-style": [
-        "error",
-        "1tbs",
-        {
-          "allowSingleLine": true
-        }
-      ],
-      "object-curly-spacing": [
-        "off",
-        "always"
-      ]
+      "import/no-unresolved": "off",
+      "import/extensions": "off"
     }
   },
   "licenses": [
@@ -125,3 +66,4 @@
   ],
   "dependencies": {}
 }
+

--- a/exercises/diffie-hellman/package.json
+++ b/exercises/diffie-hellman/package.json
@@ -10,9 +10,13 @@
   },
   "devDependencies": {
     "babel-jest": "^20.0.1",
-    "babel-preset-env": "^1.4.0",
     "babel-plugin-transform-builtin-extend": "^1.1.2",
+    "babel-preset-env": "^1.4.0",
     "eslint": "^3.19.0",
+    "eslint-config-airbnb": "^15.0.1",
+    "eslint-plugin-import": "^2.2.0",
+    "eslint-plugin-jsx-a11y": "^5.0.1",
+    "eslint-plugin-react": "^7.0.1",
     "jest": "^20.0.1"
   },
   "jest": {
@@ -49,75 +53,12 @@
     "env": {
       "es6": true,
       "node": true,
-      "jasmine": true
+      "jest": true
     },
-    "extends": "eslint:recommended",
+    "extends": "airbnb",
     "rules": {
-      "indent": [
-        "off",
-        2
-      ],
-      "block-scoped-var": "off",
-      "radix": "off",
-      "no-use-before-define": "off",
-      "one-var": [
-        "off",
-        "always"
-      ],
-      "quotes": [
-        "off",
-        "single",
-        {
-          "avoidEscape": true
-        }
-      ],
-      "semi": [
-        "off",
-        "always"
-      ],
-      "semi-spacing": [
-        "off",
-        {
-          "before": false,
-          "after": true
-        }
-      ],
-      "no-whitespace-before-property": "off",
-      "space-before-blocks": [
-        "off",
-        "always"
-      ],
-      "space-before-function-paren": [
-        "off",
-        {
-          "anonymous": "always",
-          "named": "never"
-        }
-      ],
-      "keyword-spacing": [
-        "off",
-        {
-          "before": true,
-          "after": true
-        }
-      ],
-      "no-multi-spaces": "off",
-      "no-trailing-spaces": "off",
-      "curly": [
-        "error",
-        "all"
-      ],
-      "brace-style": [
-        "error",
-        "1tbs",
-        {
-          "allowSingleLine": true
-        }
-      ],
-      "object-curly-spacing": [
-        "off",
-        "always"
-      ]
+      "import/no-unresolved": "off",
+      "import/extensions": "off"
     }
   },
   "licenses": [
@@ -125,3 +66,4 @@
   ],
   "dependencies": {}
 }
+

--- a/exercises/etl/package.json
+++ b/exercises/etl/package.json
@@ -10,9 +10,13 @@
   },
   "devDependencies": {
     "babel-jest": "^20.0.1",
-    "babel-preset-env": "^1.4.0",
     "babel-plugin-transform-builtin-extend": "^1.1.2",
+    "babel-preset-env": "^1.4.0",
     "eslint": "^3.19.0",
+    "eslint-config-airbnb": "^15.0.1",
+    "eslint-plugin-import": "^2.2.0",
+    "eslint-plugin-jsx-a11y": "^5.0.1",
+    "eslint-plugin-react": "^7.0.1",
     "jest": "^20.0.1"
   },
   "jest": {
@@ -49,75 +53,12 @@
     "env": {
       "es6": true,
       "node": true,
-      "jasmine": true
+      "jest": true
     },
-    "extends": "eslint:recommended",
+    "extends": "airbnb",
     "rules": {
-      "indent": [
-        "off",
-        2
-      ],
-      "block-scoped-var": "off",
-      "radix": "off",
-      "no-use-before-define": "off",
-      "one-var": [
-        "off",
-        "always"
-      ],
-      "quotes": [
-        "off",
-        "single",
-        {
-          "avoidEscape": true
-        }
-      ],
-      "semi": [
-        "off",
-        "always"
-      ],
-      "semi-spacing": [
-        "off",
-        {
-          "before": false,
-          "after": true
-        }
-      ],
-      "no-whitespace-before-property": "off",
-      "space-before-blocks": [
-        "off",
-        "always"
-      ],
-      "space-before-function-paren": [
-        "off",
-        {
-          "anonymous": "always",
-          "named": "never"
-        }
-      ],
-      "keyword-spacing": [
-        "off",
-        {
-          "before": true,
-          "after": true
-        }
-      ],
-      "no-multi-spaces": "off",
-      "no-trailing-spaces": "off",
-      "curly": [
-        "error",
-        "all"
-      ],
-      "brace-style": [
-        "error",
-        "1tbs",
-        {
-          "allowSingleLine": true
-        }
-      ],
-      "object-curly-spacing": [
-        "off",
-        "always"
-      ]
+      "import/no-unresolved": "off",
+      "import/extensions": "off"
     }
   },
   "licenses": [
@@ -125,3 +66,4 @@
   ],
   "dependencies": {}
 }
+

--- a/exercises/flatten-array/package.json
+++ b/exercises/flatten-array/package.json
@@ -10,9 +10,13 @@
   },
   "devDependencies": {
     "babel-jest": "^20.0.1",
-    "babel-preset-env": "^1.4.0",
     "babel-plugin-transform-builtin-extend": "^1.1.2",
+    "babel-preset-env": "^1.4.0",
     "eslint": "^3.19.0",
+    "eslint-config-airbnb": "^15.0.1",
+    "eslint-plugin-import": "^2.2.0",
+    "eslint-plugin-jsx-a11y": "^5.0.1",
+    "eslint-plugin-react": "^7.0.1",
     "jest": "^20.0.1"
   },
   "jest": {
@@ -49,75 +53,12 @@
     "env": {
       "es6": true,
       "node": true,
-      "jasmine": true
+      "jest": true
     },
-    "extends": "eslint:recommended",
+    "extends": "airbnb",
     "rules": {
-      "indent": [
-        "off",
-        2
-      ],
-      "block-scoped-var": "off",
-      "radix": "off",
-      "no-use-before-define": "off",
-      "one-var": [
-        "off",
-        "always"
-      ],
-      "quotes": [
-        "off",
-        "single",
-        {
-          "avoidEscape": true
-        }
-      ],
-      "semi": [
-        "off",
-        "always"
-      ],
-      "semi-spacing": [
-        "off",
-        {
-          "before": false,
-          "after": true
-        }
-      ],
-      "no-whitespace-before-property": "off",
-      "space-before-blocks": [
-        "off",
-        "always"
-      ],
-      "space-before-function-paren": [
-        "off",
-        {
-          "anonymous": "always",
-          "named": "never"
-        }
-      ],
-      "keyword-spacing": [
-        "off",
-        {
-          "before": true,
-          "after": true
-        }
-      ],
-      "no-multi-spaces": "off",
-      "no-trailing-spaces": "off",
-      "curly": [
-        "error",
-        "all"
-      ],
-      "brace-style": [
-        "error",
-        "1tbs",
-        {
-          "allowSingleLine": true
-        }
-      ],
-      "object-curly-spacing": [
-        "off",
-        "always"
-      ]
+      "import/no-unresolved": "off",
+      "import/extensions": "off"
     }
   },
   "licenses": [
@@ -125,3 +66,4 @@
   ],
   "dependencies": {}
 }
+

--- a/exercises/food-chain/package.json
+++ b/exercises/food-chain/package.json
@@ -10,9 +10,13 @@
   },
   "devDependencies": {
     "babel-jest": "^20.0.1",
-    "babel-preset-env": "^1.4.0",
     "babel-plugin-transform-builtin-extend": "^1.1.2",
+    "babel-preset-env": "^1.4.0",
     "eslint": "^3.19.0",
+    "eslint-config-airbnb": "^15.0.1",
+    "eslint-plugin-import": "^2.2.0",
+    "eslint-plugin-jsx-a11y": "^5.0.1",
+    "eslint-plugin-react": "^7.0.1",
     "jest": "^20.0.1"
   },
   "jest": {
@@ -49,75 +53,12 @@
     "env": {
       "es6": true,
       "node": true,
-      "jasmine": true
+      "jest": true
     },
-    "extends": "eslint:recommended",
+    "extends": "airbnb",
     "rules": {
-      "indent": [
-        "off",
-        2
-      ],
-      "block-scoped-var": "off",
-      "radix": "off",
-      "no-use-before-define": "off",
-      "one-var": [
-        "off",
-        "always"
-      ],
-      "quotes": [
-        "off",
-        "single",
-        {
-          "avoidEscape": true
-        }
-      ],
-      "semi": [
-        "off",
-        "always"
-      ],
-      "semi-spacing": [
-        "off",
-        {
-          "before": false,
-          "after": true
-        }
-      ],
-      "no-whitespace-before-property": "off",
-      "space-before-blocks": [
-        "off",
-        "always"
-      ],
-      "space-before-function-paren": [
-        "off",
-        {
-          "anonymous": "always",
-          "named": "never"
-        }
-      ],
-      "keyword-spacing": [
-        "off",
-        {
-          "before": true,
-          "after": true
-        }
-      ],
-      "no-multi-spaces": "off",
-      "no-trailing-spaces": "off",
-      "curly": [
-        "error",
-        "all"
-      ],
-      "brace-style": [
-        "error",
-        "1tbs",
-        {
-          "allowSingleLine": true
-        }
-      ],
-      "object-curly-spacing": [
-        "off",
-        "always"
-      ]
+      "import/no-unresolved": "off",
+      "import/extensions": "off"
     }
   },
   "licenses": [
@@ -125,3 +66,4 @@
   ],
   "dependencies": {}
 }
+

--- a/exercises/gigasecond/package.json
+++ b/exercises/gigasecond/package.json
@@ -10,9 +10,13 @@
   },
   "devDependencies": {
     "babel-jest": "^20.0.1",
-    "babel-preset-env": "^1.4.0",
     "babel-plugin-transform-builtin-extend": "^1.1.2",
+    "babel-preset-env": "^1.4.0",
     "eslint": "^3.19.0",
+    "eslint-config-airbnb": "^15.0.1",
+    "eslint-plugin-import": "^2.2.0",
+    "eslint-plugin-jsx-a11y": "^5.0.1",
+    "eslint-plugin-react": "^7.0.1",
     "jest": "^20.0.1"
   },
   "jest": {
@@ -49,75 +53,12 @@
     "env": {
       "es6": true,
       "node": true,
-      "jasmine": true
+      "jest": true
     },
-    "extends": "eslint:recommended",
+    "extends": "airbnb",
     "rules": {
-      "indent": [
-        "off",
-        2
-      ],
-      "block-scoped-var": "off",
-      "radix": "off",
-      "no-use-before-define": "off",
-      "one-var": [
-        "off",
-        "always"
-      ],
-      "quotes": [
-        "off",
-        "single",
-        {
-          "avoidEscape": true
-        }
-      ],
-      "semi": [
-        "off",
-        "always"
-      ],
-      "semi-spacing": [
-        "off",
-        {
-          "before": false,
-          "after": true
-        }
-      ],
-      "no-whitespace-before-property": "off",
-      "space-before-blocks": [
-        "off",
-        "always"
-      ],
-      "space-before-function-paren": [
-        "off",
-        {
-          "anonymous": "always",
-          "named": "never"
-        }
-      ],
-      "keyword-spacing": [
-        "off",
-        {
-          "before": true,
-          "after": true
-        }
-      ],
-      "no-multi-spaces": "off",
-      "no-trailing-spaces": "off",
-      "curly": [
-        "error",
-        "all"
-      ],
-      "brace-style": [
-        "error",
-        "1tbs",
-        {
-          "allowSingleLine": true
-        }
-      ],
-      "object-curly-spacing": [
-        "off",
-        "always"
-      ]
+      "import/no-unresolved": "off",
+      "import/extensions": "off"
     }
   },
   "licenses": [
@@ -125,3 +66,4 @@
   ],
   "dependencies": {}
 }
+

--- a/exercises/grade-school/package.json
+++ b/exercises/grade-school/package.json
@@ -10,9 +10,13 @@
   },
   "devDependencies": {
     "babel-jest": "^20.0.1",
-    "babel-preset-env": "^1.4.0",
     "babel-plugin-transform-builtin-extend": "^1.1.2",
+    "babel-preset-env": "^1.4.0",
     "eslint": "^3.19.0",
+    "eslint-config-airbnb": "^15.0.1",
+    "eslint-plugin-import": "^2.2.0",
+    "eslint-plugin-jsx-a11y": "^5.0.1",
+    "eslint-plugin-react": "^7.0.1",
     "jest": "^20.0.1"
   },
   "jest": {
@@ -49,75 +53,12 @@
     "env": {
       "es6": true,
       "node": true,
-      "jasmine": true
+      "jest": true
     },
-    "extends": "eslint:recommended",
+    "extends": "airbnb",
     "rules": {
-      "indent": [
-        "off",
-        2
-      ],
-      "block-scoped-var": "off",
-      "radix": "off",
-      "no-use-before-define": "off",
-      "one-var": [
-        "off",
-        "always"
-      ],
-      "quotes": [
-        "off",
-        "single",
-        {
-          "avoidEscape": true
-        }
-      ],
-      "semi": [
-        "off",
-        "always"
-      ],
-      "semi-spacing": [
-        "off",
-        {
-          "before": false,
-          "after": true
-        }
-      ],
-      "no-whitespace-before-property": "off",
-      "space-before-blocks": [
-        "off",
-        "always"
-      ],
-      "space-before-function-paren": [
-        "off",
-        {
-          "anonymous": "always",
-          "named": "never"
-        }
-      ],
-      "keyword-spacing": [
-        "off",
-        {
-          "before": true,
-          "after": true
-        }
-      ],
-      "no-multi-spaces": "off",
-      "no-trailing-spaces": "off",
-      "curly": [
-        "error",
-        "all"
-      ],
-      "brace-style": [
-        "error",
-        "1tbs",
-        {
-          "allowSingleLine": true
-        }
-      ],
-      "object-curly-spacing": [
-        "off",
-        "always"
-      ]
+      "import/no-unresolved": "off",
+      "import/extensions": "off"
     }
   },
   "licenses": [
@@ -125,3 +66,4 @@
   ],
   "dependencies": {}
 }
+

--- a/exercises/grains/package.json
+++ b/exercises/grains/package.json
@@ -10,9 +10,13 @@
   },
   "devDependencies": {
     "babel-jest": "^20.0.1",
-    "babel-preset-env": "^1.4.0",
     "babel-plugin-transform-builtin-extend": "^1.1.2",
+    "babel-preset-env": "^1.4.0",
     "eslint": "^3.19.0",
+    "eslint-config-airbnb": "^15.0.1",
+    "eslint-plugin-import": "^2.2.0",
+    "eslint-plugin-jsx-a11y": "^5.0.1",
+    "eslint-plugin-react": "^7.0.1",
     "jest": "^20.0.1"
   },
   "jest": {
@@ -49,75 +53,12 @@
     "env": {
       "es6": true,
       "node": true,
-      "jasmine": true
+      "jest": true
     },
-    "extends": "eslint:recommended",
+    "extends": "airbnb",
     "rules": {
-      "indent": [
-        "off",
-        2
-      ],
-      "block-scoped-var": "off",
-      "radix": "off",
-      "no-use-before-define": "off",
-      "one-var": [
-        "off",
-        "always"
-      ],
-      "quotes": [
-        "off",
-        "single",
-        {
-          "avoidEscape": true
-        }
-      ],
-      "semi": [
-        "off",
-        "always"
-      ],
-      "semi-spacing": [
-        "off",
-        {
-          "before": false,
-          "after": true
-        }
-      ],
-      "no-whitespace-before-property": "off",
-      "space-before-blocks": [
-        "off",
-        "always"
-      ],
-      "space-before-function-paren": [
-        "off",
-        {
-          "anonymous": "always",
-          "named": "never"
-        }
-      ],
-      "keyword-spacing": [
-        "off",
-        {
-          "before": true,
-          "after": true
-        }
-      ],
-      "no-multi-spaces": "off",
-      "no-trailing-spaces": "off",
-      "curly": [
-        "error",
-        "all"
-      ],
-      "brace-style": [
-        "error",
-        "1tbs",
-        {
-          "allowSingleLine": true
-        }
-      ],
-      "object-curly-spacing": [
-        "off",
-        "always"
-      ]
+      "import/no-unresolved": "off",
+      "import/extensions": "off"
     }
   },
   "licenses": [
@@ -125,3 +66,4 @@
   ],
   "dependencies": {}
 }
+

--- a/exercises/hamming/package.json
+++ b/exercises/hamming/package.json
@@ -10,9 +10,13 @@
   },
   "devDependencies": {
     "babel-jest": "^20.0.1",
-    "babel-preset-env": "^1.4.0",
     "babel-plugin-transform-builtin-extend": "^1.1.2",
+    "babel-preset-env": "^1.4.0",
     "eslint": "^3.19.0",
+    "eslint-config-airbnb": "^15.0.1",
+    "eslint-plugin-import": "^2.2.0",
+    "eslint-plugin-jsx-a11y": "^5.0.1",
+    "eslint-plugin-react": "^7.0.1",
     "jest": "^20.0.1"
   },
   "jest": {
@@ -49,75 +53,12 @@
     "env": {
       "es6": true,
       "node": true,
-      "jasmine": true
+      "jest": true
     },
-    "extends": "eslint:recommended",
+    "extends": "airbnb",
     "rules": {
-      "indent": [
-        "off",
-        2
-      ],
-      "block-scoped-var": "off",
-      "radix": "off",
-      "no-use-before-define": "off",
-      "one-var": [
-        "off",
-        "always"
-      ],
-      "quotes": [
-        "off",
-        "single",
-        {
-          "avoidEscape": true
-        }
-      ],
-      "semi": [
-        "off",
-        "always"
-      ],
-      "semi-spacing": [
-        "off",
-        {
-          "before": false,
-          "after": true
-        }
-      ],
-      "no-whitespace-before-property": "off",
-      "space-before-blocks": [
-        "off",
-        "always"
-      ],
-      "space-before-function-paren": [
-        "off",
-        {
-          "anonymous": "always",
-          "named": "never"
-        }
-      ],
-      "keyword-spacing": [
-        "off",
-        {
-          "before": true,
-          "after": true
-        }
-      ],
-      "no-multi-spaces": "off",
-      "no-trailing-spaces": "off",
-      "curly": [
-        "error",
-        "all"
-      ],
-      "brace-style": [
-        "error",
-        "1tbs",
-        {
-          "allowSingleLine": true
-        }
-      ],
-      "object-curly-spacing": [
-        "off",
-        "always"
-      ]
+      "import/no-unresolved": "off",
+      "import/extensions": "off"
     }
   },
   "licenses": [
@@ -125,3 +66,4 @@
   ],
   "dependencies": {}
 }
+

--- a/exercises/hello-world/package.json
+++ b/exercises/hello-world/package.json
@@ -10,9 +10,13 @@
   },
   "devDependencies": {
     "babel-jest": "^20.0.1",
-    "babel-preset-env": "^1.4.0",
     "babel-plugin-transform-builtin-extend": "^1.1.2",
+    "babel-preset-env": "^1.4.0",
     "eslint": "^3.19.0",
+    "eslint-config-airbnb": "^15.0.1",
+    "eslint-plugin-import": "^2.2.0",
+    "eslint-plugin-jsx-a11y": "^5.0.1",
+    "eslint-plugin-react": "^7.0.1",
     "jest": "^20.0.1"
   },
   "jest": {
@@ -49,75 +53,12 @@
     "env": {
       "es6": true,
       "node": true,
-      "jasmine": true
+      "jest": true
     },
-    "extends": "eslint:recommended",
+    "extends": "airbnb",
     "rules": {
-      "indent": [
-        "off",
-        2
-      ],
-      "block-scoped-var": "off",
-      "radix": "off",
-      "no-use-before-define": "off",
-      "one-var": [
-        "off",
-        "always"
-      ],
-      "quotes": [
-        "off",
-        "single",
-        {
-          "avoidEscape": true
-        }
-      ],
-      "semi": [
-        "off",
-        "always"
-      ],
-      "semi-spacing": [
-        "off",
-        {
-          "before": false,
-          "after": true
-        }
-      ],
-      "no-whitespace-before-property": "off",
-      "space-before-blocks": [
-        "off",
-        "always"
-      ],
-      "space-before-function-paren": [
-        "off",
-        {
-          "anonymous": "always",
-          "named": "never"
-        }
-      ],
-      "keyword-spacing": [
-        "off",
-        {
-          "before": true,
-          "after": true
-        }
-      ],
-      "no-multi-spaces": "off",
-      "no-trailing-spaces": "off",
-      "curly": [
-        "error",
-        "all"
-      ],
-      "brace-style": [
-        "error",
-        "1tbs",
-        {
-          "allowSingleLine": true
-        }
-      ],
-      "object-curly-spacing": [
-        "off",
-        "always"
-      ]
+      "import/no-unresolved": "off",
+      "import/extensions": "off"
     }
   },
   "licenses": [
@@ -125,3 +66,4 @@
   ],
   "dependencies": {}
 }
+

--- a/exercises/hexadecimal/package.json
+++ b/exercises/hexadecimal/package.json
@@ -10,9 +10,13 @@
   },
   "devDependencies": {
     "babel-jest": "^20.0.1",
-    "babel-preset-env": "^1.4.0",
     "babel-plugin-transform-builtin-extend": "^1.1.2",
+    "babel-preset-env": "^1.4.0",
     "eslint": "^3.19.0",
+    "eslint-config-airbnb": "^15.0.1",
+    "eslint-plugin-import": "^2.2.0",
+    "eslint-plugin-jsx-a11y": "^5.0.1",
+    "eslint-plugin-react": "^7.0.1",
     "jest": "^20.0.1"
   },
   "jest": {
@@ -49,75 +53,12 @@
     "env": {
       "es6": true,
       "node": true,
-      "jasmine": true
+      "jest": true
     },
-    "extends": "eslint:recommended",
+    "extends": "airbnb",
     "rules": {
-      "indent": [
-        "off",
-        2
-      ],
-      "block-scoped-var": "off",
-      "radix": "off",
-      "no-use-before-define": "off",
-      "one-var": [
-        "off",
-        "always"
-      ],
-      "quotes": [
-        "off",
-        "single",
-        {
-          "avoidEscape": true
-        }
-      ],
-      "semi": [
-        "off",
-        "always"
-      ],
-      "semi-spacing": [
-        "off",
-        {
-          "before": false,
-          "after": true
-        }
-      ],
-      "no-whitespace-before-property": "off",
-      "space-before-blocks": [
-        "off",
-        "always"
-      ],
-      "space-before-function-paren": [
-        "off",
-        {
-          "anonymous": "always",
-          "named": "never"
-        }
-      ],
-      "keyword-spacing": [
-        "off",
-        {
-          "before": true,
-          "after": true
-        }
-      ],
-      "no-multi-spaces": "off",
-      "no-trailing-spaces": "off",
-      "curly": [
-        "error",
-        "all"
-      ],
-      "brace-style": [
-        "error",
-        "1tbs",
-        {
-          "allowSingleLine": true
-        }
-      ],
-      "object-curly-spacing": [
-        "off",
-        "always"
-      ]
+      "import/no-unresolved": "off",
+      "import/extensions": "off"
     }
   },
   "licenses": [
@@ -125,3 +66,4 @@
   ],
   "dependencies": {}
 }
+

--- a/exercises/isogram/package.json
+++ b/exercises/isogram/package.json
@@ -10,9 +10,13 @@
   },
   "devDependencies": {
     "babel-jest": "^20.0.1",
-    "babel-preset-env": "^1.4.0",
     "babel-plugin-transform-builtin-extend": "^1.1.2",
+    "babel-preset-env": "^1.4.0",
     "eslint": "^3.19.0",
+    "eslint-config-airbnb": "^15.0.1",
+    "eslint-plugin-import": "^2.2.0",
+    "eslint-plugin-jsx-a11y": "^5.0.1",
+    "eslint-plugin-react": "^7.0.1",
     "jest": "^20.0.1"
   },
   "jest": {
@@ -49,75 +53,12 @@
     "env": {
       "es6": true,
       "node": true,
-      "jasmine": true
+      "jest": true
     },
-    "extends": "eslint:recommended",
+    "extends": "airbnb",
     "rules": {
-      "indent": [
-        "off",
-        2
-      ],
-      "block-scoped-var": "off",
-      "radix": "off",
-      "no-use-before-define": "off",
-      "one-var": [
-        "off",
-        "always"
-      ],
-      "quotes": [
-        "off",
-        "single",
-        {
-          "avoidEscape": true
-        }
-      ],
-      "semi": [
-        "off",
-        "always"
-      ],
-      "semi-spacing": [
-        "off",
-        {
-          "before": false,
-          "after": true
-        }
-      ],
-      "no-whitespace-before-property": "off",
-      "space-before-blocks": [
-        "off",
-        "always"
-      ],
-      "space-before-function-paren": [
-        "off",
-        {
-          "anonymous": "always",
-          "named": "never"
-        }
-      ],
-      "keyword-spacing": [
-        "off",
-        {
-          "before": true,
-          "after": true
-        }
-      ],
-      "no-multi-spaces": "off",
-      "no-trailing-spaces": "off",
-      "curly": [
-        "error",
-        "all"
-      ],
-      "brace-style": [
-        "error",
-        "1tbs",
-        {
-          "allowSingleLine": true
-        }
-      ],
-      "object-curly-spacing": [
-        "off",
-        "always"
-      ]
+      "import/no-unresolved": "off",
+      "import/extensions": "off"
     }
   },
   "licenses": [
@@ -125,3 +66,4 @@
   ],
   "dependencies": {}
 }
+

--- a/exercises/kindergarten-garden/package.json
+++ b/exercises/kindergarten-garden/package.json
@@ -10,9 +10,13 @@
   },
   "devDependencies": {
     "babel-jest": "^20.0.1",
-    "babel-preset-env": "^1.4.0",
     "babel-plugin-transform-builtin-extend": "^1.1.2",
+    "babel-preset-env": "^1.4.0",
     "eslint": "^3.19.0",
+    "eslint-config-airbnb": "^15.0.1",
+    "eslint-plugin-import": "^2.2.0",
+    "eslint-plugin-jsx-a11y": "^5.0.1",
+    "eslint-plugin-react": "^7.0.1",
     "jest": "^20.0.1"
   },
   "jest": {
@@ -49,75 +53,12 @@
     "env": {
       "es6": true,
       "node": true,
-      "jasmine": true
+      "jest": true
     },
-    "extends": "eslint:recommended",
+    "extends": "airbnb",
     "rules": {
-      "indent": [
-        "off",
-        2
-      ],
-      "block-scoped-var": "off",
-      "radix": "off",
-      "no-use-before-define": "off",
-      "one-var": [
-        "off",
-        "always"
-      ],
-      "quotes": [
-        "off",
-        "single",
-        {
-          "avoidEscape": true
-        }
-      ],
-      "semi": [
-        "off",
-        "always"
-      ],
-      "semi-spacing": [
-        "off",
-        {
-          "before": false,
-          "after": true
-        }
-      ],
-      "no-whitespace-before-property": "off",
-      "space-before-blocks": [
-        "off",
-        "always"
-      ],
-      "space-before-function-paren": [
-        "off",
-        {
-          "anonymous": "always",
-          "named": "never"
-        }
-      ],
-      "keyword-spacing": [
-        "off",
-        {
-          "before": true,
-          "after": true
-        }
-      ],
-      "no-multi-spaces": "off",
-      "no-trailing-spaces": "off",
-      "curly": [
-        "error",
-        "all"
-      ],
-      "brace-style": [
-        "error",
-        "1tbs",
-        {
-          "allowSingleLine": true
-        }
-      ],
-      "object-curly-spacing": [
-        "off",
-        "always"
-      ]
+      "import/no-unresolved": "off",
+      "import/extensions": "off"
     }
   },
   "licenses": [
@@ -125,3 +66,4 @@
   ],
   "dependencies": {}
 }
+

--- a/exercises/largest-series-product/package.json
+++ b/exercises/largest-series-product/package.json
@@ -10,9 +10,13 @@
   },
   "devDependencies": {
     "babel-jest": "^20.0.1",
-    "babel-preset-env": "^1.4.0",
     "babel-plugin-transform-builtin-extend": "^1.1.2",
+    "babel-preset-env": "^1.4.0",
     "eslint": "^3.19.0",
+    "eslint-config-airbnb": "^15.0.1",
+    "eslint-plugin-import": "^2.2.0",
+    "eslint-plugin-jsx-a11y": "^5.0.1",
+    "eslint-plugin-react": "^7.0.1",
     "jest": "^20.0.1"
   },
   "jest": {
@@ -49,75 +53,12 @@
     "env": {
       "es6": true,
       "node": true,
-      "jasmine": true
+      "jest": true
     },
-    "extends": "eslint:recommended",
+    "extends": "airbnb",
     "rules": {
-      "indent": [
-        "off",
-        2
-      ],
-      "block-scoped-var": "off",
-      "radix": "off",
-      "no-use-before-define": "off",
-      "one-var": [
-        "off",
-        "always"
-      ],
-      "quotes": [
-        "off",
-        "single",
-        {
-          "avoidEscape": true
-        }
-      ],
-      "semi": [
-        "off",
-        "always"
-      ],
-      "semi-spacing": [
-        "off",
-        {
-          "before": false,
-          "after": true
-        }
-      ],
-      "no-whitespace-before-property": "off",
-      "space-before-blocks": [
-        "off",
-        "always"
-      ],
-      "space-before-function-paren": [
-        "off",
-        {
-          "anonymous": "always",
-          "named": "never"
-        }
-      ],
-      "keyword-spacing": [
-        "off",
-        {
-          "before": true,
-          "after": true
-        }
-      ],
-      "no-multi-spaces": "off",
-      "no-trailing-spaces": "off",
-      "curly": [
-        "error",
-        "all"
-      ],
-      "brace-style": [
-        "error",
-        "1tbs",
-        {
-          "allowSingleLine": true
-        }
-      ],
-      "object-curly-spacing": [
-        "off",
-        "always"
-      ]
+      "import/no-unresolved": "off",
+      "import/extensions": "off"
     }
   },
   "licenses": [
@@ -125,3 +66,4 @@
   ],
   "dependencies": {}
 }
+

--- a/exercises/leap/package.json
+++ b/exercises/leap/package.json
@@ -10,9 +10,13 @@
   },
   "devDependencies": {
     "babel-jest": "^20.0.1",
-    "babel-preset-env": "^1.4.0",
     "babel-plugin-transform-builtin-extend": "^1.1.2",
+    "babel-preset-env": "^1.4.0",
     "eslint": "^3.19.0",
+    "eslint-config-airbnb": "^15.0.1",
+    "eslint-plugin-import": "^2.2.0",
+    "eslint-plugin-jsx-a11y": "^5.0.1",
+    "eslint-plugin-react": "^7.0.1",
     "jest": "^20.0.1"
   },
   "jest": {
@@ -49,75 +53,12 @@
     "env": {
       "es6": true,
       "node": true,
-      "jasmine": true
+      "jest": true
     },
-    "extends": "eslint:recommended",
+    "extends": "airbnb",
     "rules": {
-      "indent": [
-        "off",
-        2
-      ],
-      "block-scoped-var": "off",
-      "radix": "off",
-      "no-use-before-define": "off",
-      "one-var": [
-        "off",
-        "always"
-      ],
-      "quotes": [
-        "off",
-        "single",
-        {
-          "avoidEscape": true
-        }
-      ],
-      "semi": [
-        "off",
-        "always"
-      ],
-      "semi-spacing": [
-        "off",
-        {
-          "before": false,
-          "after": true
-        }
-      ],
-      "no-whitespace-before-property": "off",
-      "space-before-blocks": [
-        "off",
-        "always"
-      ],
-      "space-before-function-paren": [
-        "off",
-        {
-          "anonymous": "always",
-          "named": "never"
-        }
-      ],
-      "keyword-spacing": [
-        "off",
-        {
-          "before": true,
-          "after": true
-        }
-      ],
-      "no-multi-spaces": "off",
-      "no-trailing-spaces": "off",
-      "curly": [
-        "error",
-        "all"
-      ],
-      "brace-style": [
-        "error",
-        "1tbs",
-        {
-          "allowSingleLine": true
-        }
-      ],
-      "object-curly-spacing": [
-        "off",
-        "always"
-      ]
+      "import/no-unresolved": "off",
+      "import/extensions": "off"
     }
   },
   "licenses": [
@@ -125,3 +66,4 @@
   ],
   "dependencies": {}
 }
+

--- a/exercises/linked-list/package.json
+++ b/exercises/linked-list/package.json
@@ -10,9 +10,13 @@
   },
   "devDependencies": {
     "babel-jest": "^20.0.1",
-    "babel-preset-env": "^1.4.0",
     "babel-plugin-transform-builtin-extend": "^1.1.2",
+    "babel-preset-env": "^1.4.0",
     "eslint": "^3.19.0",
+    "eslint-config-airbnb": "^15.0.1",
+    "eslint-plugin-import": "^2.2.0",
+    "eslint-plugin-jsx-a11y": "^5.0.1",
+    "eslint-plugin-react": "^7.0.1",
     "jest": "^20.0.1"
   },
   "jest": {
@@ -49,75 +53,12 @@
     "env": {
       "es6": true,
       "node": true,
-      "jasmine": true
+      "jest": true
     },
-    "extends": "eslint:recommended",
+    "extends": "airbnb",
     "rules": {
-      "indent": [
-        "off",
-        2
-      ],
-      "block-scoped-var": "off",
-      "radix": "off",
-      "no-use-before-define": "off",
-      "one-var": [
-        "off",
-        "always"
-      ],
-      "quotes": [
-        "off",
-        "single",
-        {
-          "avoidEscape": true
-        }
-      ],
-      "semi": [
-        "off",
-        "always"
-      ],
-      "semi-spacing": [
-        "off",
-        {
-          "before": false,
-          "after": true
-        }
-      ],
-      "no-whitespace-before-property": "off",
-      "space-before-blocks": [
-        "off",
-        "always"
-      ],
-      "space-before-function-paren": [
-        "off",
-        {
-          "anonymous": "always",
-          "named": "never"
-        }
-      ],
-      "keyword-spacing": [
-        "off",
-        {
-          "before": true,
-          "after": true
-        }
-      ],
-      "no-multi-spaces": "off",
-      "no-trailing-spaces": "off",
-      "curly": [
-        "error",
-        "all"
-      ],
-      "brace-style": [
-        "error",
-        "1tbs",
-        {
-          "allowSingleLine": true
-        }
-      ],
-      "object-curly-spacing": [
-        "off",
-        "always"
-      ]
+      "import/no-unresolved": "off",
+      "import/extensions": "off"
     }
   },
   "licenses": [
@@ -125,3 +66,4 @@
   ],
   "dependencies": {}
 }
+

--- a/exercises/list-ops/package.json
+++ b/exercises/list-ops/package.json
@@ -10,9 +10,13 @@
   },
   "devDependencies": {
     "babel-jest": "^20.0.1",
-    "babel-preset-env": "^1.4.0",
     "babel-plugin-transform-builtin-extend": "^1.1.2",
+    "babel-preset-env": "^1.4.0",
     "eslint": "^3.19.0",
+    "eslint-config-airbnb": "^15.0.1",
+    "eslint-plugin-import": "^2.2.0",
+    "eslint-plugin-jsx-a11y": "^5.0.1",
+    "eslint-plugin-react": "^7.0.1",
     "jest": "^20.0.1"
   },
   "jest": {
@@ -49,75 +53,12 @@
     "env": {
       "es6": true,
       "node": true,
-      "jasmine": true
+      "jest": true
     },
-    "extends": "eslint:recommended",
+    "extends": "airbnb",
     "rules": {
-      "indent": [
-        "off",
-        2
-      ],
-      "block-scoped-var": "off",
-      "radix": "off",
-      "no-use-before-define": "off",
-      "one-var": [
-        "off",
-        "always"
-      ],
-      "quotes": [
-        "off",
-        "single",
-        {
-          "avoidEscape": true
-        }
-      ],
-      "semi": [
-        "off",
-        "always"
-      ],
-      "semi-spacing": [
-        "off",
-        {
-          "before": false,
-          "after": true
-        }
-      ],
-      "no-whitespace-before-property": "off",
-      "space-before-blocks": [
-        "off",
-        "always"
-      ],
-      "space-before-function-paren": [
-        "off",
-        {
-          "anonymous": "always",
-          "named": "never"
-        }
-      ],
-      "keyword-spacing": [
-        "off",
-        {
-          "before": true,
-          "after": true
-        }
-      ],
-      "no-multi-spaces": "off",
-      "no-trailing-spaces": "off",
-      "curly": [
-        "error",
-        "all"
-      ],
-      "brace-style": [
-        "error",
-        "1tbs",
-        {
-          "allowSingleLine": true
-        }
-      ],
-      "object-curly-spacing": [
-        "off",
-        "always"
-      ]
+      "import/no-unresolved": "off",
+      "import/extensions": "off"
     }
   },
   "licenses": [
@@ -125,3 +66,4 @@
   ],
   "dependencies": {}
 }
+

--- a/exercises/luhn/package.json
+++ b/exercises/luhn/package.json
@@ -10,9 +10,13 @@
   },
   "devDependencies": {
     "babel-jest": "^20.0.1",
-    "babel-preset-env": "^1.4.0",
     "babel-plugin-transform-builtin-extend": "^1.1.2",
+    "babel-preset-env": "^1.4.0",
     "eslint": "^3.19.0",
+    "eslint-config-airbnb": "^15.0.1",
+    "eslint-plugin-import": "^2.2.0",
+    "eslint-plugin-jsx-a11y": "^5.0.1",
+    "eslint-plugin-react": "^7.0.1",
     "jest": "^20.0.1"
   },
   "jest": {
@@ -49,75 +53,12 @@
     "env": {
       "es6": true,
       "node": true,
-      "jasmine": true
+      "jest": true
     },
-    "extends": "eslint:recommended",
+    "extends": "airbnb",
     "rules": {
-      "indent": [
-        "off",
-        2
-      ],
-      "block-scoped-var": "off",
-      "radix": "off",
-      "no-use-before-define": "off",
-      "one-var": [
-        "off",
-        "always"
-      ],
-      "quotes": [
-        "off",
-        "single",
-        {
-          "avoidEscape": true
-        }
-      ],
-      "semi": [
-        "off",
-        "always"
-      ],
-      "semi-spacing": [
-        "off",
-        {
-          "before": false,
-          "after": true
-        }
-      ],
-      "no-whitespace-before-property": "off",
-      "space-before-blocks": [
-        "off",
-        "always"
-      ],
-      "space-before-function-paren": [
-        "off",
-        {
-          "anonymous": "always",
-          "named": "never"
-        }
-      ],
-      "keyword-spacing": [
-        "off",
-        {
-          "before": true,
-          "after": true
-        }
-      ],
-      "no-multi-spaces": "off",
-      "no-trailing-spaces": "off",
-      "curly": [
-        "error",
-        "all"
-      ],
-      "brace-style": [
-        "error",
-        "1tbs",
-        {
-          "allowSingleLine": true
-        }
-      ],
-      "object-curly-spacing": [
-        "off",
-        "always"
-      ]
+      "import/no-unresolved": "off",
+      "import/extensions": "off"
     }
   },
   "licenses": [
@@ -125,3 +66,4 @@
   ],
   "dependencies": {}
 }
+

--- a/exercises/matrix/package.json
+++ b/exercises/matrix/package.json
@@ -10,9 +10,13 @@
   },
   "devDependencies": {
     "babel-jest": "^20.0.1",
-    "babel-preset-env": "^1.4.0",
     "babel-plugin-transform-builtin-extend": "^1.1.2",
+    "babel-preset-env": "^1.4.0",
     "eslint": "^3.19.0",
+    "eslint-config-airbnb": "^15.0.1",
+    "eslint-plugin-import": "^2.2.0",
+    "eslint-plugin-jsx-a11y": "^5.0.1",
+    "eslint-plugin-react": "^7.0.1",
     "jest": "^20.0.1"
   },
   "jest": {
@@ -49,75 +53,12 @@
     "env": {
       "es6": true,
       "node": true,
-      "jasmine": true
+      "jest": true
     },
-    "extends": "eslint:recommended",
+    "extends": "airbnb",
     "rules": {
-      "indent": [
-        "off",
-        2
-      ],
-      "block-scoped-var": "off",
-      "radix": "off",
-      "no-use-before-define": "off",
-      "one-var": [
-        "off",
-        "always"
-      ],
-      "quotes": [
-        "off",
-        "single",
-        {
-          "avoidEscape": true
-        }
-      ],
-      "semi": [
-        "off",
-        "always"
-      ],
-      "semi-spacing": [
-        "off",
-        {
-          "before": false,
-          "after": true
-        }
-      ],
-      "no-whitespace-before-property": "off",
-      "space-before-blocks": [
-        "off",
-        "always"
-      ],
-      "space-before-function-paren": [
-        "off",
-        {
-          "anonymous": "always",
-          "named": "never"
-        }
-      ],
-      "keyword-spacing": [
-        "off",
-        {
-          "before": true,
-          "after": true
-        }
-      ],
-      "no-multi-spaces": "off",
-      "no-trailing-spaces": "off",
-      "curly": [
-        "error",
-        "all"
-      ],
-      "brace-style": [
-        "error",
-        "1tbs",
-        {
-          "allowSingleLine": true
-        }
-      ],
-      "object-curly-spacing": [
-        "off",
-        "always"
-      ]
+      "import/no-unresolved": "off",
+      "import/extensions": "off"
     }
   },
   "licenses": [
@@ -125,3 +66,4 @@
   ],
   "dependencies": {}
 }
+

--- a/exercises/meetup/package.json
+++ b/exercises/meetup/package.json
@@ -10,9 +10,13 @@
   },
   "devDependencies": {
     "babel-jest": "^20.0.1",
-    "babel-preset-env": "^1.4.0",
     "babel-plugin-transform-builtin-extend": "^1.1.2",
+    "babel-preset-env": "^1.4.0",
     "eslint": "^3.19.0",
+    "eslint-config-airbnb": "^15.0.1",
+    "eslint-plugin-import": "^2.2.0",
+    "eslint-plugin-jsx-a11y": "^5.0.1",
+    "eslint-plugin-react": "^7.0.1",
     "jest": "^20.0.1"
   },
   "jest": {
@@ -49,75 +53,12 @@
     "env": {
       "es6": true,
       "node": true,
-      "jasmine": true
+      "jest": true
     },
-    "extends": "eslint:recommended",
+    "extends": "airbnb",
     "rules": {
-      "indent": [
-        "off",
-        2
-      ],
-      "block-scoped-var": "off",
-      "radix": "off",
-      "no-use-before-define": "off",
-      "one-var": [
-        "off",
-        "always"
-      ],
-      "quotes": [
-        "off",
-        "single",
-        {
-          "avoidEscape": true
-        }
-      ],
-      "semi": [
-        "off",
-        "always"
-      ],
-      "semi-spacing": [
-        "off",
-        {
-          "before": false,
-          "after": true
-        }
-      ],
-      "no-whitespace-before-property": "off",
-      "space-before-blocks": [
-        "off",
-        "always"
-      ],
-      "space-before-function-paren": [
-        "off",
-        {
-          "anonymous": "always",
-          "named": "never"
-        }
-      ],
-      "keyword-spacing": [
-        "off",
-        {
-          "before": true,
-          "after": true
-        }
-      ],
-      "no-multi-spaces": "off",
-      "no-trailing-spaces": "off",
-      "curly": [
-        "error",
-        "all"
-      ],
-      "brace-style": [
-        "error",
-        "1tbs",
-        {
-          "allowSingleLine": true
-        }
-      ],
-      "object-curly-spacing": [
-        "off",
-        "always"
-      ]
+      "import/no-unresolved": "off",
+      "import/extensions": "off"
     }
   },
   "licenses": [
@@ -125,3 +66,4 @@
   ],
   "dependencies": {}
 }
+

--- a/exercises/nth-prime/package.json
+++ b/exercises/nth-prime/package.json
@@ -10,9 +10,13 @@
   },
   "devDependencies": {
     "babel-jest": "^20.0.1",
-    "babel-preset-env": "^1.4.0",
     "babel-plugin-transform-builtin-extend": "^1.1.2",
+    "babel-preset-env": "^1.4.0",
     "eslint": "^3.19.0",
+    "eslint-config-airbnb": "^15.0.1",
+    "eslint-plugin-import": "^2.2.0",
+    "eslint-plugin-jsx-a11y": "^5.0.1",
+    "eslint-plugin-react": "^7.0.1",
     "jest": "^20.0.1"
   },
   "jest": {
@@ -49,75 +53,12 @@
     "env": {
       "es6": true,
       "node": true,
-      "jasmine": true
+      "jest": true
     },
-    "extends": "eslint:recommended",
+    "extends": "airbnb",
     "rules": {
-      "indent": [
-        "off",
-        2
-      ],
-      "block-scoped-var": "off",
-      "radix": "off",
-      "no-use-before-define": "off",
-      "one-var": [
-        "off",
-        "always"
-      ],
-      "quotes": [
-        "off",
-        "single",
-        {
-          "avoidEscape": true
-        }
-      ],
-      "semi": [
-        "off",
-        "always"
-      ],
-      "semi-spacing": [
-        "off",
-        {
-          "before": false,
-          "after": true
-        }
-      ],
-      "no-whitespace-before-property": "off",
-      "space-before-blocks": [
-        "off",
-        "always"
-      ],
-      "space-before-function-paren": [
-        "off",
-        {
-          "anonymous": "always",
-          "named": "never"
-        }
-      ],
-      "keyword-spacing": [
-        "off",
-        {
-          "before": true,
-          "after": true
-        }
-      ],
-      "no-multi-spaces": "off",
-      "no-trailing-spaces": "off",
-      "curly": [
-        "error",
-        "all"
-      ],
-      "brace-style": [
-        "error",
-        "1tbs",
-        {
-          "allowSingleLine": true
-        }
-      ],
-      "object-curly-spacing": [
-        "off",
-        "always"
-      ]
+      "import/no-unresolved": "off",
+      "import/extensions": "off"
     }
   },
   "licenses": [
@@ -125,3 +66,4 @@
   ],
   "dependencies": {}
 }
+

--- a/exercises/ocr-numbers/package.json
+++ b/exercises/ocr-numbers/package.json
@@ -10,9 +10,13 @@
   },
   "devDependencies": {
     "babel-jest": "^20.0.1",
-    "babel-preset-env": "^1.4.0",
     "babel-plugin-transform-builtin-extend": "^1.1.2",
+    "babel-preset-env": "^1.4.0",
     "eslint": "^3.19.0",
+    "eslint-config-airbnb": "^15.0.1",
+    "eslint-plugin-import": "^2.2.0",
+    "eslint-plugin-jsx-a11y": "^5.0.1",
+    "eslint-plugin-react": "^7.0.1",
     "jest": "^20.0.1"
   },
   "jest": {
@@ -49,75 +53,12 @@
     "env": {
       "es6": true,
       "node": true,
-      "jasmine": true
+      "jest": true
     },
-    "extends": "eslint:recommended",
+    "extends": "airbnb",
     "rules": {
-      "indent": [
-        "off",
-        2
-      ],
-      "block-scoped-var": "off",
-      "radix": "off",
-      "no-use-before-define": "off",
-      "one-var": [
-        "off",
-        "always"
-      ],
-      "quotes": [
-        "off",
-        "single",
-        {
-          "avoidEscape": true
-        }
-      ],
-      "semi": [
-        "off",
-        "always"
-      ],
-      "semi-spacing": [
-        "off",
-        {
-          "before": false,
-          "after": true
-        }
-      ],
-      "no-whitespace-before-property": "off",
-      "space-before-blocks": [
-        "off",
-        "always"
-      ],
-      "space-before-function-paren": [
-        "off",
-        {
-          "anonymous": "always",
-          "named": "never"
-        }
-      ],
-      "keyword-spacing": [
-        "off",
-        {
-          "before": true,
-          "after": true
-        }
-      ],
-      "no-multi-spaces": "off",
-      "no-trailing-spaces": "off",
-      "curly": [
-        "error",
-        "all"
-      ],
-      "brace-style": [
-        "error",
-        "1tbs",
-        {
-          "allowSingleLine": true
-        }
-      ],
-      "object-curly-spacing": [
-        "off",
-        "always"
-      ]
+      "import/no-unresolved": "off",
+      "import/extensions": "off"
     }
   },
   "licenses": [
@@ -125,3 +66,4 @@
   ],
   "dependencies": {}
 }
+

--- a/exercises/octal/package.json
+++ b/exercises/octal/package.json
@@ -10,9 +10,13 @@
   },
   "devDependencies": {
     "babel-jest": "^20.0.1",
-    "babel-preset-env": "^1.4.0",
     "babel-plugin-transform-builtin-extend": "^1.1.2",
+    "babel-preset-env": "^1.4.0",
     "eslint": "^3.19.0",
+    "eslint-config-airbnb": "^15.0.1",
+    "eslint-plugin-import": "^2.2.0",
+    "eslint-plugin-jsx-a11y": "^5.0.1",
+    "eslint-plugin-react": "^7.0.1",
     "jest": "^20.0.1"
   },
   "jest": {
@@ -49,75 +53,12 @@
     "env": {
       "es6": true,
       "node": true,
-      "jasmine": true
+      "jest": true
     },
-    "extends": "eslint:recommended",
+    "extends": "airbnb",
     "rules": {
-      "indent": [
-        "off",
-        2
-      ],
-      "block-scoped-var": "off",
-      "radix": "off",
-      "no-use-before-define": "off",
-      "one-var": [
-        "off",
-        "always"
-      ],
-      "quotes": [
-        "off",
-        "single",
-        {
-          "avoidEscape": true
-        }
-      ],
-      "semi": [
-        "off",
-        "always"
-      ],
-      "semi-spacing": [
-        "off",
-        {
-          "before": false,
-          "after": true
-        }
-      ],
-      "no-whitespace-before-property": "off",
-      "space-before-blocks": [
-        "off",
-        "always"
-      ],
-      "space-before-function-paren": [
-        "off",
-        {
-          "anonymous": "always",
-          "named": "never"
-        }
-      ],
-      "keyword-spacing": [
-        "off",
-        {
-          "before": true,
-          "after": true
-        }
-      ],
-      "no-multi-spaces": "off",
-      "no-trailing-spaces": "off",
-      "curly": [
-        "error",
-        "all"
-      ],
-      "brace-style": [
-        "error",
-        "1tbs",
-        {
-          "allowSingleLine": true
-        }
-      ],
-      "object-curly-spacing": [
-        "off",
-        "always"
-      ]
+      "import/no-unresolved": "off",
+      "import/extensions": "off"
     }
   },
   "licenses": [
@@ -125,3 +66,4 @@
   ],
   "dependencies": {}
 }
+

--- a/exercises/palindrome-products/package.json
+++ b/exercises/palindrome-products/package.json
@@ -10,9 +10,13 @@
   },
   "devDependencies": {
     "babel-jest": "^20.0.1",
-    "babel-preset-env": "^1.4.0",
     "babel-plugin-transform-builtin-extend": "^1.1.2",
+    "babel-preset-env": "^1.4.0",
     "eslint": "^3.19.0",
+    "eslint-config-airbnb": "^15.0.1",
+    "eslint-plugin-import": "^2.2.0",
+    "eslint-plugin-jsx-a11y": "^5.0.1",
+    "eslint-plugin-react": "^7.0.1",
     "jest": "^20.0.1"
   },
   "jest": {
@@ -49,75 +53,12 @@
     "env": {
       "es6": true,
       "node": true,
-      "jasmine": true
+      "jest": true
     },
-    "extends": "eslint:recommended",
+    "extends": "airbnb",
     "rules": {
-      "indent": [
-        "off",
-        2
-      ],
-      "block-scoped-var": "off",
-      "radix": "off",
-      "no-use-before-define": "off",
-      "one-var": [
-        "off",
-        "always"
-      ],
-      "quotes": [
-        "off",
-        "single",
-        {
-          "avoidEscape": true
-        }
-      ],
-      "semi": [
-        "off",
-        "always"
-      ],
-      "semi-spacing": [
-        "off",
-        {
-          "before": false,
-          "after": true
-        }
-      ],
-      "no-whitespace-before-property": "off",
-      "space-before-blocks": [
-        "off",
-        "always"
-      ],
-      "space-before-function-paren": [
-        "off",
-        {
-          "anonymous": "always",
-          "named": "never"
-        }
-      ],
-      "keyword-spacing": [
-        "off",
-        {
-          "before": true,
-          "after": true
-        }
-      ],
-      "no-multi-spaces": "off",
-      "no-trailing-spaces": "off",
-      "curly": [
-        "error",
-        "all"
-      ],
-      "brace-style": [
-        "error",
-        "1tbs",
-        {
-          "allowSingleLine": true
-        }
-      ],
-      "object-curly-spacing": [
-        "off",
-        "always"
-      ]
+      "import/no-unresolved": "off",
+      "import/extensions": "off"
     }
   },
   "licenses": [
@@ -125,3 +66,4 @@
   ],
   "dependencies": {}
 }
+

--- a/exercises/pangram/package.json
+++ b/exercises/pangram/package.json
@@ -10,9 +10,13 @@
   },
   "devDependencies": {
     "babel-jest": "^20.0.1",
-    "babel-preset-env": "^1.4.0",
     "babel-plugin-transform-builtin-extend": "^1.1.2",
+    "babel-preset-env": "^1.4.0",
     "eslint": "^3.19.0",
+    "eslint-config-airbnb": "^15.0.1",
+    "eslint-plugin-import": "^2.2.0",
+    "eslint-plugin-jsx-a11y": "^5.0.1",
+    "eslint-plugin-react": "^7.0.1",
     "jest": "^20.0.1"
   },
   "jest": {
@@ -49,75 +53,12 @@
     "env": {
       "es6": true,
       "node": true,
-      "jasmine": true
+      "jest": true
     },
-    "extends": "eslint:recommended",
+    "extends": "airbnb",
     "rules": {
-      "indent": [
-        "off",
-        2
-      ],
-      "block-scoped-var": "off",
-      "radix": "off",
-      "no-use-before-define": "off",
-      "one-var": [
-        "off",
-        "always"
-      ],
-      "quotes": [
-        "off",
-        "single",
-        {
-          "avoidEscape": true
-        }
-      ],
-      "semi": [
-        "off",
-        "always"
-      ],
-      "semi-spacing": [
-        "off",
-        {
-          "before": false,
-          "after": true
-        }
-      ],
-      "no-whitespace-before-property": "off",
-      "space-before-blocks": [
-        "off",
-        "always"
-      ],
-      "space-before-function-paren": [
-        "off",
-        {
-          "anonymous": "always",
-          "named": "never"
-        }
-      ],
-      "keyword-spacing": [
-        "off",
-        {
-          "before": true,
-          "after": true
-        }
-      ],
-      "no-multi-spaces": "off",
-      "no-trailing-spaces": "off",
-      "curly": [
-        "error",
-        "all"
-      ],
-      "brace-style": [
-        "error",
-        "1tbs",
-        {
-          "allowSingleLine": true
-        }
-      ],
-      "object-curly-spacing": [
-        "off",
-        "always"
-      ]
+      "import/no-unresolved": "off",
+      "import/extensions": "off"
     }
   },
   "licenses": [
@@ -125,3 +66,4 @@
   ],
   "dependencies": {}
 }
+

--- a/exercises/pascals-triangle/package.json
+++ b/exercises/pascals-triangle/package.json
@@ -10,9 +10,13 @@
   },
   "devDependencies": {
     "babel-jest": "^20.0.1",
-    "babel-preset-env": "^1.4.0",
     "babel-plugin-transform-builtin-extend": "^1.1.2",
+    "babel-preset-env": "^1.4.0",
     "eslint": "^3.19.0",
+    "eslint-config-airbnb": "^15.0.1",
+    "eslint-plugin-import": "^2.2.0",
+    "eslint-plugin-jsx-a11y": "^5.0.1",
+    "eslint-plugin-react": "^7.0.1",
     "jest": "^20.0.1"
   },
   "jest": {
@@ -49,75 +53,12 @@
     "env": {
       "es6": true,
       "node": true,
-      "jasmine": true
+      "jest": true
     },
-    "extends": "eslint:recommended",
+    "extends": "airbnb",
     "rules": {
-      "indent": [
-        "off",
-        2
-      ],
-      "block-scoped-var": "off",
-      "radix": "off",
-      "no-use-before-define": "off",
-      "one-var": [
-        "off",
-        "always"
-      ],
-      "quotes": [
-        "off",
-        "single",
-        {
-          "avoidEscape": true
-        }
-      ],
-      "semi": [
-        "off",
-        "always"
-      ],
-      "semi-spacing": [
-        "off",
-        {
-          "before": false,
-          "after": true
-        }
-      ],
-      "no-whitespace-before-property": "off",
-      "space-before-blocks": [
-        "off",
-        "always"
-      ],
-      "space-before-function-paren": [
-        "off",
-        {
-          "anonymous": "always",
-          "named": "never"
-        }
-      ],
-      "keyword-spacing": [
-        "off",
-        {
-          "before": true,
-          "after": true
-        }
-      ],
-      "no-multi-spaces": "off",
-      "no-trailing-spaces": "off",
-      "curly": [
-        "error",
-        "all"
-      ],
-      "brace-style": [
-        "error",
-        "1tbs",
-        {
-          "allowSingleLine": true
-        }
-      ],
-      "object-curly-spacing": [
-        "off",
-        "always"
-      ]
+      "import/no-unresolved": "off",
+      "import/extensions": "off"
     }
   },
   "licenses": [
@@ -125,3 +66,4 @@
   ],
   "dependencies": {}
 }
+

--- a/exercises/perfect-numbers/package.json
+++ b/exercises/perfect-numbers/package.json
@@ -10,9 +10,13 @@
   },
   "devDependencies": {
     "babel-jest": "^20.0.1",
-    "babel-preset-env": "^1.4.0",
     "babel-plugin-transform-builtin-extend": "^1.1.2",
+    "babel-preset-env": "^1.4.0",
     "eslint": "^3.19.0",
+    "eslint-config-airbnb": "^15.0.1",
+    "eslint-plugin-import": "^2.2.0",
+    "eslint-plugin-jsx-a11y": "^5.0.1",
+    "eslint-plugin-react": "^7.0.1",
     "jest": "^20.0.1"
   },
   "jest": {
@@ -49,75 +53,12 @@
     "env": {
       "es6": true,
       "node": true,
-      "jasmine": true
+      "jest": true
     },
-    "extends": "eslint:recommended",
+    "extends": "airbnb",
     "rules": {
-      "indent": [
-        "off",
-        2
-      ],
-      "block-scoped-var": "off",
-      "radix": "off",
-      "no-use-before-define": "off",
-      "one-var": [
-        "off",
-        "always"
-      ],
-      "quotes": [
-        "off",
-        "single",
-        {
-          "avoidEscape": true
-        }
-      ],
-      "semi": [
-        "off",
-        "always"
-      ],
-      "semi-spacing": [
-        "off",
-        {
-          "before": false,
-          "after": true
-        }
-      ],
-      "no-whitespace-before-property": "off",
-      "space-before-blocks": [
-        "off",
-        "always"
-      ],
-      "space-before-function-paren": [
-        "off",
-        {
-          "anonymous": "always",
-          "named": "never"
-        }
-      ],
-      "keyword-spacing": [
-        "off",
-        {
-          "before": true,
-          "after": true
-        }
-      ],
-      "no-multi-spaces": "off",
-      "no-trailing-spaces": "off",
-      "curly": [
-        "error",
-        "all"
-      ],
-      "brace-style": [
-        "error",
-        "1tbs",
-        {
-          "allowSingleLine": true
-        }
-      ],
-      "object-curly-spacing": [
-        "off",
-        "always"
-      ]
+      "import/no-unresolved": "off",
+      "import/extensions": "off"
     }
   },
   "licenses": [
@@ -125,3 +66,4 @@
   ],
   "dependencies": {}
 }
+

--- a/exercises/phone-number/package.json
+++ b/exercises/phone-number/package.json
@@ -10,9 +10,13 @@
   },
   "devDependencies": {
     "babel-jest": "^20.0.1",
-    "babel-preset-env": "^1.4.0",
     "babel-plugin-transform-builtin-extend": "^1.1.2",
+    "babel-preset-env": "^1.4.0",
     "eslint": "^3.19.0",
+    "eslint-config-airbnb": "^15.0.1",
+    "eslint-plugin-import": "^2.2.0",
+    "eslint-plugin-jsx-a11y": "^5.0.1",
+    "eslint-plugin-react": "^7.0.1",
     "jest": "^20.0.1"
   },
   "jest": {
@@ -49,75 +53,12 @@
     "env": {
       "es6": true,
       "node": true,
-      "jasmine": true
+      "jest": true
     },
-    "extends": "eslint:recommended",
+    "extends": "airbnb",
     "rules": {
-      "indent": [
-        "off",
-        2
-      ],
-      "block-scoped-var": "off",
-      "radix": "off",
-      "no-use-before-define": "off",
-      "one-var": [
-        "off",
-        "always"
-      ],
-      "quotes": [
-        "off",
-        "single",
-        {
-          "avoidEscape": true
-        }
-      ],
-      "semi": [
-        "off",
-        "always"
-      ],
-      "semi-spacing": [
-        "off",
-        {
-          "before": false,
-          "after": true
-        }
-      ],
-      "no-whitespace-before-property": "off",
-      "space-before-blocks": [
-        "off",
-        "always"
-      ],
-      "space-before-function-paren": [
-        "off",
-        {
-          "anonymous": "always",
-          "named": "never"
-        }
-      ],
-      "keyword-spacing": [
-        "off",
-        {
-          "before": true,
-          "after": true
-        }
-      ],
-      "no-multi-spaces": "off",
-      "no-trailing-spaces": "off",
-      "curly": [
-        "error",
-        "all"
-      ],
-      "brace-style": [
-        "error",
-        "1tbs",
-        {
-          "allowSingleLine": true
-        }
-      ],
-      "object-curly-spacing": [
-        "off",
-        "always"
-      ]
+      "import/no-unresolved": "off",
+      "import/extensions": "off"
     }
   },
   "licenses": [
@@ -125,3 +66,4 @@
   ],
   "dependencies": {}
 }
+

--- a/exercises/pig-latin/package.json
+++ b/exercises/pig-latin/package.json
@@ -10,9 +10,13 @@
   },
   "devDependencies": {
     "babel-jest": "^20.0.1",
-    "babel-preset-env": "^1.4.0",
     "babel-plugin-transform-builtin-extend": "^1.1.2",
+    "babel-preset-env": "^1.4.0",
     "eslint": "^3.19.0",
+    "eslint-config-airbnb": "^15.0.1",
+    "eslint-plugin-import": "^2.2.0",
+    "eslint-plugin-jsx-a11y": "^5.0.1",
+    "eslint-plugin-react": "^7.0.1",
     "jest": "^20.0.1"
   },
   "jest": {
@@ -49,75 +53,12 @@
     "env": {
       "es6": true,
       "node": true,
-      "jasmine": true
+      "jest": true
     },
-    "extends": "eslint:recommended",
+    "extends": "airbnb",
     "rules": {
-      "indent": [
-        "off",
-        2
-      ],
-      "block-scoped-var": "off",
-      "radix": "off",
-      "no-use-before-define": "off",
-      "one-var": [
-        "off",
-        "always"
-      ],
-      "quotes": [
-        "off",
-        "single",
-        {
-          "avoidEscape": true
-        }
-      ],
-      "semi": [
-        "off",
-        "always"
-      ],
-      "semi-spacing": [
-        "off",
-        {
-          "before": false,
-          "after": true
-        }
-      ],
-      "no-whitespace-before-property": "off",
-      "space-before-blocks": [
-        "off",
-        "always"
-      ],
-      "space-before-function-paren": [
-        "off",
-        {
-          "anonymous": "always",
-          "named": "never"
-        }
-      ],
-      "keyword-spacing": [
-        "off",
-        {
-          "before": true,
-          "after": true
-        }
-      ],
-      "no-multi-spaces": "off",
-      "no-trailing-spaces": "off",
-      "curly": [
-        "error",
-        "all"
-      ],
-      "brace-style": [
-        "error",
-        "1tbs",
-        {
-          "allowSingleLine": true
-        }
-      ],
-      "object-curly-spacing": [
-        "off",
-        "always"
-      ]
+      "import/no-unresolved": "off",
+      "import/extensions": "off"
     }
   },
   "licenses": [
@@ -125,3 +66,4 @@
   ],
   "dependencies": {}
 }
+

--- a/exercises/prime-factors/package.json
+++ b/exercises/prime-factors/package.json
@@ -10,9 +10,13 @@
   },
   "devDependencies": {
     "babel-jest": "^20.0.1",
-    "babel-preset-env": "^1.4.0",
     "babel-plugin-transform-builtin-extend": "^1.1.2",
+    "babel-preset-env": "^1.4.0",
     "eslint": "^3.19.0",
+    "eslint-config-airbnb": "^15.0.1",
+    "eslint-plugin-import": "^2.2.0",
+    "eslint-plugin-jsx-a11y": "^5.0.1",
+    "eslint-plugin-react": "^7.0.1",
     "jest": "^20.0.1"
   },
   "jest": {
@@ -49,75 +53,12 @@
     "env": {
       "es6": true,
       "node": true,
-      "jasmine": true
+      "jest": true
     },
-    "extends": "eslint:recommended",
+    "extends": "airbnb",
     "rules": {
-      "indent": [
-        "off",
-        2
-      ],
-      "block-scoped-var": "off",
-      "radix": "off",
-      "no-use-before-define": "off",
-      "one-var": [
-        "off",
-        "always"
-      ],
-      "quotes": [
-        "off",
-        "single",
-        {
-          "avoidEscape": true
-        }
-      ],
-      "semi": [
-        "off",
-        "always"
-      ],
-      "semi-spacing": [
-        "off",
-        {
-          "before": false,
-          "after": true
-        }
-      ],
-      "no-whitespace-before-property": "off",
-      "space-before-blocks": [
-        "off",
-        "always"
-      ],
-      "space-before-function-paren": [
-        "off",
-        {
-          "anonymous": "always",
-          "named": "never"
-        }
-      ],
-      "keyword-spacing": [
-        "off",
-        {
-          "before": true,
-          "after": true
-        }
-      ],
-      "no-multi-spaces": "off",
-      "no-trailing-spaces": "off",
-      "curly": [
-        "error",
-        "all"
-      ],
-      "brace-style": [
-        "error",
-        "1tbs",
-        {
-          "allowSingleLine": true
-        }
-      ],
-      "object-curly-spacing": [
-        "off",
-        "always"
-      ]
+      "import/no-unresolved": "off",
+      "import/extensions": "off"
     }
   },
   "licenses": [
@@ -125,3 +66,4 @@
   ],
   "dependencies": {}
 }
+

--- a/exercises/pythagorean-triplet/package.json
+++ b/exercises/pythagorean-triplet/package.json
@@ -10,9 +10,13 @@
   },
   "devDependencies": {
     "babel-jest": "^20.0.1",
-    "babel-preset-env": "^1.4.0",
     "babel-plugin-transform-builtin-extend": "^1.1.2",
+    "babel-preset-env": "^1.4.0",
     "eslint": "^3.19.0",
+    "eslint-config-airbnb": "^15.0.1",
+    "eslint-plugin-import": "^2.2.0",
+    "eslint-plugin-jsx-a11y": "^5.0.1",
+    "eslint-plugin-react": "^7.0.1",
     "jest": "^20.0.1"
   },
   "jest": {
@@ -49,75 +53,12 @@
     "env": {
       "es6": true,
       "node": true,
-      "jasmine": true
+      "jest": true
     },
-    "extends": "eslint:recommended",
+    "extends": "airbnb",
     "rules": {
-      "indent": [
-        "off",
-        2
-      ],
-      "block-scoped-var": "off",
-      "radix": "off",
-      "no-use-before-define": "off",
-      "one-var": [
-        "off",
-        "always"
-      ],
-      "quotes": [
-        "off",
-        "single",
-        {
-          "avoidEscape": true
-        }
-      ],
-      "semi": [
-        "off",
-        "always"
-      ],
-      "semi-spacing": [
-        "off",
-        {
-          "before": false,
-          "after": true
-        }
-      ],
-      "no-whitespace-before-property": "off",
-      "space-before-blocks": [
-        "off",
-        "always"
-      ],
-      "space-before-function-paren": [
-        "off",
-        {
-          "anonymous": "always",
-          "named": "never"
-        }
-      ],
-      "keyword-spacing": [
-        "off",
-        {
-          "before": true,
-          "after": true
-        }
-      ],
-      "no-multi-spaces": "off",
-      "no-trailing-spaces": "off",
-      "curly": [
-        "error",
-        "all"
-      ],
-      "brace-style": [
-        "error",
-        "1tbs",
-        {
-          "allowSingleLine": true
-        }
-      ],
-      "object-curly-spacing": [
-        "off",
-        "always"
-      ]
+      "import/no-unresolved": "off",
+      "import/extensions": "off"
     }
   },
   "licenses": [
@@ -125,3 +66,4 @@
   ],
   "dependencies": {}
 }
+

--- a/exercises/queen-attack/package.json
+++ b/exercises/queen-attack/package.json
@@ -10,9 +10,13 @@
   },
   "devDependencies": {
     "babel-jest": "^20.0.1",
-    "babel-preset-env": "^1.4.0",
     "babel-plugin-transform-builtin-extend": "^1.1.2",
+    "babel-preset-env": "^1.4.0",
     "eslint": "^3.19.0",
+    "eslint-config-airbnb": "^15.0.1",
+    "eslint-plugin-import": "^2.2.0",
+    "eslint-plugin-jsx-a11y": "^5.0.1",
+    "eslint-plugin-react": "^7.0.1",
     "jest": "^20.0.1"
   },
   "jest": {
@@ -49,75 +53,12 @@
     "env": {
       "es6": true,
       "node": true,
-      "jasmine": true
+      "jest": true
     },
-    "extends": "eslint:recommended",
+    "extends": "airbnb",
     "rules": {
-      "indent": [
-        "off",
-        2
-      ],
-      "block-scoped-var": "off",
-      "radix": "off",
-      "no-use-before-define": "off",
-      "one-var": [
-        "off",
-        "always"
-      ],
-      "quotes": [
-        "off",
-        "single",
-        {
-          "avoidEscape": true
-        }
-      ],
-      "semi": [
-        "off",
-        "always"
-      ],
-      "semi-spacing": [
-        "off",
-        {
-          "before": false,
-          "after": true
-        }
-      ],
-      "no-whitespace-before-property": "off",
-      "space-before-blocks": [
-        "off",
-        "always"
-      ],
-      "space-before-function-paren": [
-        "off",
-        {
-          "anonymous": "always",
-          "named": "never"
-        }
-      ],
-      "keyword-spacing": [
-        "off",
-        {
-          "before": true,
-          "after": true
-        }
-      ],
-      "no-multi-spaces": "off",
-      "no-trailing-spaces": "off",
-      "curly": [
-        "error",
-        "all"
-      ],
-      "brace-style": [
-        "error",
-        "1tbs",
-        {
-          "allowSingleLine": true
-        }
-      ],
-      "object-curly-spacing": [
-        "off",
-        "always"
-      ]
+      "import/no-unresolved": "off",
+      "import/extensions": "off"
     }
   },
   "licenses": [
@@ -125,3 +66,4 @@
   ],
   "dependencies": {}
 }
+

--- a/exercises/raindrops/package.json
+++ b/exercises/raindrops/package.json
@@ -10,9 +10,13 @@
   },
   "devDependencies": {
     "babel-jest": "^20.0.1",
-    "babel-preset-env": "^1.4.0",
     "babel-plugin-transform-builtin-extend": "^1.1.2",
+    "babel-preset-env": "^1.4.0",
     "eslint": "^3.19.0",
+    "eslint-config-airbnb": "^15.0.1",
+    "eslint-plugin-import": "^2.2.0",
+    "eslint-plugin-jsx-a11y": "^5.0.1",
+    "eslint-plugin-react": "^7.0.1",
     "jest": "^20.0.1"
   },
   "jest": {
@@ -49,75 +53,12 @@
     "env": {
       "es6": true,
       "node": true,
-      "jasmine": true
+      "jest": true
     },
-    "extends": "eslint:recommended",
+    "extends": "airbnb",
     "rules": {
-      "indent": [
-        "off",
-        2
-      ],
-      "block-scoped-var": "off",
-      "radix": "off",
-      "no-use-before-define": "off",
-      "one-var": [
-        "off",
-        "always"
-      ],
-      "quotes": [
-        "off",
-        "single",
-        {
-          "avoidEscape": true
-        }
-      ],
-      "semi": [
-        "off",
-        "always"
-      ],
-      "semi-spacing": [
-        "off",
-        {
-          "before": false,
-          "after": true
-        }
-      ],
-      "no-whitespace-before-property": "off",
-      "space-before-blocks": [
-        "off",
-        "always"
-      ],
-      "space-before-function-paren": [
-        "off",
-        {
-          "anonymous": "always",
-          "named": "never"
-        }
-      ],
-      "keyword-spacing": [
-        "off",
-        {
-          "before": true,
-          "after": true
-        }
-      ],
-      "no-multi-spaces": "off",
-      "no-trailing-spaces": "off",
-      "curly": [
-        "error",
-        "all"
-      ],
-      "brace-style": [
-        "error",
-        "1tbs",
-        {
-          "allowSingleLine": true
-        }
-      ],
-      "object-curly-spacing": [
-        "off",
-        "always"
-      ]
+      "import/no-unresolved": "off",
+      "import/extensions": "off"
     }
   },
   "licenses": [
@@ -125,3 +66,4 @@
   ],
   "dependencies": {}
 }
+

--- a/exercises/rna-transcription/package.json
+++ b/exercises/rna-transcription/package.json
@@ -10,9 +10,13 @@
   },
   "devDependencies": {
     "babel-jest": "^20.0.1",
-    "babel-preset-env": "^1.4.0",
     "babel-plugin-transform-builtin-extend": "^1.1.2",
+    "babel-preset-env": "^1.4.0",
     "eslint": "^3.19.0",
+    "eslint-config-airbnb": "^15.0.1",
+    "eslint-plugin-import": "^2.2.0",
+    "eslint-plugin-jsx-a11y": "^5.0.1",
+    "eslint-plugin-react": "^7.0.1",
     "jest": "^20.0.1"
   },
   "jest": {
@@ -49,75 +53,12 @@
     "env": {
       "es6": true,
       "node": true,
-      "jasmine": true
+      "jest": true
     },
-    "extends": "eslint:recommended",
+    "extends": "airbnb",
     "rules": {
-      "indent": [
-        "off",
-        2
-      ],
-      "block-scoped-var": "off",
-      "radix": "off",
-      "no-use-before-define": "off",
-      "one-var": [
-        "off",
-        "always"
-      ],
-      "quotes": [
-        "off",
-        "single",
-        {
-          "avoidEscape": true
-        }
-      ],
-      "semi": [
-        "off",
-        "always"
-      ],
-      "semi-spacing": [
-        "off",
-        {
-          "before": false,
-          "after": true
-        }
-      ],
-      "no-whitespace-before-property": "off",
-      "space-before-blocks": [
-        "off",
-        "always"
-      ],
-      "space-before-function-paren": [
-        "off",
-        {
-          "anonymous": "always",
-          "named": "never"
-        }
-      ],
-      "keyword-spacing": [
-        "off",
-        {
-          "before": true,
-          "after": true
-        }
-      ],
-      "no-multi-spaces": "off",
-      "no-trailing-spaces": "off",
-      "curly": [
-        "error",
-        "all"
-      ],
-      "brace-style": [
-        "error",
-        "1tbs",
-        {
-          "allowSingleLine": true
-        }
-      ],
-      "object-curly-spacing": [
-        "off",
-        "always"
-      ]
+      "import/no-unresolved": "off",
+      "import/extensions": "off"
     }
   },
   "licenses": [
@@ -125,3 +66,4 @@
   ],
   "dependencies": {}
 }
+

--- a/exercises/robot-name/package.json
+++ b/exercises/robot-name/package.json
@@ -10,9 +10,13 @@
   },
   "devDependencies": {
     "babel-jest": "^20.0.1",
-    "babel-preset-env": "^1.4.0",
     "babel-plugin-transform-builtin-extend": "^1.1.2",
+    "babel-preset-env": "^1.4.0",
     "eslint": "^3.19.0",
+    "eslint-config-airbnb": "^15.0.1",
+    "eslint-plugin-import": "^2.2.0",
+    "eslint-plugin-jsx-a11y": "^5.0.1",
+    "eslint-plugin-react": "^7.0.1",
     "jest": "^20.0.1"
   },
   "jest": {
@@ -49,75 +53,12 @@
     "env": {
       "es6": true,
       "node": true,
-      "jasmine": true
+      "jest": true
     },
-    "extends": "eslint:recommended",
+    "extends": "airbnb",
     "rules": {
-      "indent": [
-        "off",
-        2
-      ],
-      "block-scoped-var": "off",
-      "radix": "off",
-      "no-use-before-define": "off",
-      "one-var": [
-        "off",
-        "always"
-      ],
-      "quotes": [
-        "off",
-        "single",
-        {
-          "avoidEscape": true
-        }
-      ],
-      "semi": [
-        "off",
-        "always"
-      ],
-      "semi-spacing": [
-        "off",
-        {
-          "before": false,
-          "after": true
-        }
-      ],
-      "no-whitespace-before-property": "off",
-      "space-before-blocks": [
-        "off",
-        "always"
-      ],
-      "space-before-function-paren": [
-        "off",
-        {
-          "anonymous": "always",
-          "named": "never"
-        }
-      ],
-      "keyword-spacing": [
-        "off",
-        {
-          "before": true,
-          "after": true
-        }
-      ],
-      "no-multi-spaces": "off",
-      "no-trailing-spaces": "off",
-      "curly": [
-        "error",
-        "all"
-      ],
-      "brace-style": [
-        "error",
-        "1tbs",
-        {
-          "allowSingleLine": true
-        }
-      ],
-      "object-curly-spacing": [
-        "off",
-        "always"
-      ]
+      "import/no-unresolved": "off",
+      "import/extensions": "off"
     }
   },
   "licenses": [
@@ -125,3 +66,4 @@
   ],
   "dependencies": {}
 }
+

--- a/exercises/robot-simulator/package.json
+++ b/exercises/robot-simulator/package.json
@@ -10,9 +10,13 @@
   },
   "devDependencies": {
     "babel-jest": "^20.0.1",
-    "babel-preset-env": "^1.4.0",
     "babel-plugin-transform-builtin-extend": "^1.1.2",
+    "babel-preset-env": "^1.4.0",
     "eslint": "^3.19.0",
+    "eslint-config-airbnb": "^15.0.1",
+    "eslint-plugin-import": "^2.2.0",
+    "eslint-plugin-jsx-a11y": "^5.0.1",
+    "eslint-plugin-react": "^7.0.1",
     "jest": "^20.0.1"
   },
   "jest": {
@@ -49,75 +53,12 @@
     "env": {
       "es6": true,
       "node": true,
-      "jasmine": true
+      "jest": true
     },
-    "extends": "eslint:recommended",
+    "extends": "airbnb",
     "rules": {
-      "indent": [
-        "off",
-        2
-      ],
-      "block-scoped-var": "off",
-      "radix": "off",
-      "no-use-before-define": "off",
-      "one-var": [
-        "off",
-        "always"
-      ],
-      "quotes": [
-        "off",
-        "single",
-        {
-          "avoidEscape": true
-        }
-      ],
-      "semi": [
-        "off",
-        "always"
-      ],
-      "semi-spacing": [
-        "off",
-        {
-          "before": false,
-          "after": true
-        }
-      ],
-      "no-whitespace-before-property": "off",
-      "space-before-blocks": [
-        "off",
-        "always"
-      ],
-      "space-before-function-paren": [
-        "off",
-        {
-          "anonymous": "always",
-          "named": "never"
-        }
-      ],
-      "keyword-spacing": [
-        "off",
-        {
-          "before": true,
-          "after": true
-        }
-      ],
-      "no-multi-spaces": "off",
-      "no-trailing-spaces": "off",
-      "curly": [
-        "error",
-        "all"
-      ],
-      "brace-style": [
-        "error",
-        "1tbs",
-        {
-          "allowSingleLine": true
-        }
-      ],
-      "object-curly-spacing": [
-        "off",
-        "always"
-      ]
+      "import/no-unresolved": "off",
+      "import/extensions": "off"
     }
   },
   "licenses": [
@@ -125,3 +66,4 @@
   ],
   "dependencies": {}
 }
+

--- a/exercises/roman-numerals/package.json
+++ b/exercises/roman-numerals/package.json
@@ -10,9 +10,13 @@
   },
   "devDependencies": {
     "babel-jest": "^20.0.1",
-    "babel-preset-env": "^1.4.0",
     "babel-plugin-transform-builtin-extend": "^1.1.2",
+    "babel-preset-env": "^1.4.0",
     "eslint": "^3.19.0",
+    "eslint-config-airbnb": "^15.0.1",
+    "eslint-plugin-import": "^2.2.0",
+    "eslint-plugin-jsx-a11y": "^5.0.1",
+    "eslint-plugin-react": "^7.0.1",
     "jest": "^20.0.1"
   },
   "jest": {
@@ -49,75 +53,12 @@
     "env": {
       "es6": true,
       "node": true,
-      "jasmine": true
+      "jest": true
     },
-    "extends": "eslint:recommended",
+    "extends": "airbnb",
     "rules": {
-      "indent": [
-        "off",
-        2
-      ],
-      "block-scoped-var": "off",
-      "radix": "off",
-      "no-use-before-define": "off",
-      "one-var": [
-        "off",
-        "always"
-      ],
-      "quotes": [
-        "off",
-        "single",
-        {
-          "avoidEscape": true
-        }
-      ],
-      "semi": [
-        "off",
-        "always"
-      ],
-      "semi-spacing": [
-        "off",
-        {
-          "before": false,
-          "after": true
-        }
-      ],
-      "no-whitespace-before-property": "off",
-      "space-before-blocks": [
-        "off",
-        "always"
-      ],
-      "space-before-function-paren": [
-        "off",
-        {
-          "anonymous": "always",
-          "named": "never"
-        }
-      ],
-      "keyword-spacing": [
-        "off",
-        {
-          "before": true,
-          "after": true
-        }
-      ],
-      "no-multi-spaces": "off",
-      "no-trailing-spaces": "off",
-      "curly": [
-        "error",
-        "all"
-      ],
-      "brace-style": [
-        "error",
-        "1tbs",
-        {
-          "allowSingleLine": true
-        }
-      ],
-      "object-curly-spacing": [
-        "off",
-        "always"
-      ]
+      "import/no-unresolved": "off",
+      "import/extensions": "off"
     }
   },
   "licenses": [
@@ -125,3 +66,4 @@
   ],
   "dependencies": {}
 }
+

--- a/exercises/saddle-points/package.json
+++ b/exercises/saddle-points/package.json
@@ -10,9 +10,13 @@
   },
   "devDependencies": {
     "babel-jest": "^20.0.1",
-    "babel-preset-env": "^1.4.0",
     "babel-plugin-transform-builtin-extend": "^1.1.2",
+    "babel-preset-env": "^1.4.0",
     "eslint": "^3.19.0",
+    "eslint-config-airbnb": "^15.0.1",
+    "eslint-plugin-import": "^2.2.0",
+    "eslint-plugin-jsx-a11y": "^5.0.1",
+    "eslint-plugin-react": "^7.0.1",
     "jest": "^20.0.1"
   },
   "jest": {
@@ -49,75 +53,12 @@
     "env": {
       "es6": true,
       "node": true,
-      "jasmine": true
+      "jest": true
     },
-    "extends": "eslint:recommended",
+    "extends": "airbnb",
     "rules": {
-      "indent": [
-        "off",
-        2
-      ],
-      "block-scoped-var": "off",
-      "radix": "off",
-      "no-use-before-define": "off",
-      "one-var": [
-        "off",
-        "always"
-      ],
-      "quotes": [
-        "off",
-        "single",
-        {
-          "avoidEscape": true
-        }
-      ],
-      "semi": [
-        "off",
-        "always"
-      ],
-      "semi-spacing": [
-        "off",
-        {
-          "before": false,
-          "after": true
-        }
-      ],
-      "no-whitespace-before-property": "off",
-      "space-before-blocks": [
-        "off",
-        "always"
-      ],
-      "space-before-function-paren": [
-        "off",
-        {
-          "anonymous": "always",
-          "named": "never"
-        }
-      ],
-      "keyword-spacing": [
-        "off",
-        {
-          "before": true,
-          "after": true
-        }
-      ],
-      "no-multi-spaces": "off",
-      "no-trailing-spaces": "off",
-      "curly": [
-        "error",
-        "all"
-      ],
-      "brace-style": [
-        "error",
-        "1tbs",
-        {
-          "allowSingleLine": true
-        }
-      ],
-      "object-curly-spacing": [
-        "off",
-        "always"
-      ]
+      "import/no-unresolved": "off",
+      "import/extensions": "off"
     }
   },
   "licenses": [
@@ -125,3 +66,4 @@
   ],
   "dependencies": {}
 }
+

--- a/exercises/say/package.json
+++ b/exercises/say/package.json
@@ -10,9 +10,13 @@
   },
   "devDependencies": {
     "babel-jest": "^20.0.1",
-    "babel-preset-env": "^1.4.0",
     "babel-plugin-transform-builtin-extend": "^1.1.2",
+    "babel-preset-env": "^1.4.0",
     "eslint": "^3.19.0",
+    "eslint-config-airbnb": "^15.0.1",
+    "eslint-plugin-import": "^2.2.0",
+    "eslint-plugin-jsx-a11y": "^5.0.1",
+    "eslint-plugin-react": "^7.0.1",
     "jest": "^20.0.1"
   },
   "jest": {
@@ -49,75 +53,12 @@
     "env": {
       "es6": true,
       "node": true,
-      "jasmine": true
+      "jest": true
     },
-    "extends": "eslint:recommended",
+    "extends": "airbnb",
     "rules": {
-      "indent": [
-        "off",
-        2
-      ],
-      "block-scoped-var": "off",
-      "radix": "off",
-      "no-use-before-define": "off",
-      "one-var": [
-        "off",
-        "always"
-      ],
-      "quotes": [
-        "off",
-        "single",
-        {
-          "avoidEscape": true
-        }
-      ],
-      "semi": [
-        "off",
-        "always"
-      ],
-      "semi-spacing": [
-        "off",
-        {
-          "before": false,
-          "after": true
-        }
-      ],
-      "no-whitespace-before-property": "off",
-      "space-before-blocks": [
-        "off",
-        "always"
-      ],
-      "space-before-function-paren": [
-        "off",
-        {
-          "anonymous": "always",
-          "named": "never"
-        }
-      ],
-      "keyword-spacing": [
-        "off",
-        {
-          "before": true,
-          "after": true
-        }
-      ],
-      "no-multi-spaces": "off",
-      "no-trailing-spaces": "off",
-      "curly": [
-        "error",
-        "all"
-      ],
-      "brace-style": [
-        "error",
-        "1tbs",
-        {
-          "allowSingleLine": true
-        }
-      ],
-      "object-curly-spacing": [
-        "off",
-        "always"
-      ]
+      "import/no-unresolved": "off",
+      "import/extensions": "off"
     }
   },
   "licenses": [
@@ -125,3 +66,4 @@
   ],
   "dependencies": {}
 }
+

--- a/exercises/scrabble-score/package.json
+++ b/exercises/scrabble-score/package.json
@@ -10,9 +10,13 @@
   },
   "devDependencies": {
     "babel-jest": "^20.0.1",
-    "babel-preset-env": "^1.4.0",
     "babel-plugin-transform-builtin-extend": "^1.1.2",
+    "babel-preset-env": "^1.4.0",
     "eslint": "^3.19.0",
+    "eslint-config-airbnb": "^15.0.1",
+    "eslint-plugin-import": "^2.2.0",
+    "eslint-plugin-jsx-a11y": "^5.0.1",
+    "eslint-plugin-react": "^7.0.1",
     "jest": "^20.0.1"
   },
   "jest": {
@@ -49,75 +53,12 @@
     "env": {
       "es6": true,
       "node": true,
-      "jasmine": true
+      "jest": true
     },
-    "extends": "eslint:recommended",
+    "extends": "airbnb",
     "rules": {
-      "indent": [
-        "off",
-        2
-      ],
-      "block-scoped-var": "off",
-      "radix": "off",
-      "no-use-before-define": "off",
-      "one-var": [
-        "off",
-        "always"
-      ],
-      "quotes": [
-        "off",
-        "single",
-        {
-          "avoidEscape": true
-        }
-      ],
-      "semi": [
-        "off",
-        "always"
-      ],
-      "semi-spacing": [
-        "off",
-        {
-          "before": false,
-          "after": true
-        }
-      ],
-      "no-whitespace-before-property": "off",
-      "space-before-blocks": [
-        "off",
-        "always"
-      ],
-      "space-before-function-paren": [
-        "off",
-        {
-          "anonymous": "always",
-          "named": "never"
-        }
-      ],
-      "keyword-spacing": [
-        "off",
-        {
-          "before": true,
-          "after": true
-        }
-      ],
-      "no-multi-spaces": "off",
-      "no-trailing-spaces": "off",
-      "curly": [
-        "error",
-        "all"
-      ],
-      "brace-style": [
-        "error",
-        "1tbs",
-        {
-          "allowSingleLine": true
-        }
-      ],
-      "object-curly-spacing": [
-        "off",
-        "always"
-      ]
+      "import/no-unresolved": "off",
+      "import/extensions": "off"
     }
   },
   "licenses": [
@@ -125,3 +66,4 @@
   ],
   "dependencies": {}
 }
+

--- a/exercises/secret-handshake/package.json
+++ b/exercises/secret-handshake/package.json
@@ -10,9 +10,13 @@
   },
   "devDependencies": {
     "babel-jest": "^20.0.1",
-    "babel-preset-env": "^1.4.0",
     "babel-plugin-transform-builtin-extend": "^1.1.2",
+    "babel-preset-env": "^1.4.0",
     "eslint": "^3.19.0",
+    "eslint-config-airbnb": "^15.0.1",
+    "eslint-plugin-import": "^2.2.0",
+    "eslint-plugin-jsx-a11y": "^5.0.1",
+    "eslint-plugin-react": "^7.0.1",
     "jest": "^20.0.1"
   },
   "jest": {
@@ -49,75 +53,12 @@
     "env": {
       "es6": true,
       "node": true,
-      "jasmine": true
+      "jest": true
     },
-    "extends": "eslint:recommended",
+    "extends": "airbnb",
     "rules": {
-      "indent": [
-        "off",
-        2
-      ],
-      "block-scoped-var": "off",
-      "radix": "off",
-      "no-use-before-define": "off",
-      "one-var": [
-        "off",
-        "always"
-      ],
-      "quotes": [
-        "off",
-        "single",
-        {
-          "avoidEscape": true
-        }
-      ],
-      "semi": [
-        "off",
-        "always"
-      ],
-      "semi-spacing": [
-        "off",
-        {
-          "before": false,
-          "after": true
-        }
-      ],
-      "no-whitespace-before-property": "off",
-      "space-before-blocks": [
-        "off",
-        "always"
-      ],
-      "space-before-function-paren": [
-        "off",
-        {
-          "anonymous": "always",
-          "named": "never"
-        }
-      ],
-      "keyword-spacing": [
-        "off",
-        {
-          "before": true,
-          "after": true
-        }
-      ],
-      "no-multi-spaces": "off",
-      "no-trailing-spaces": "off",
-      "curly": [
-        "error",
-        "all"
-      ],
-      "brace-style": [
-        "error",
-        "1tbs",
-        {
-          "allowSingleLine": true
-        }
-      ],
-      "object-curly-spacing": [
-        "off",
-        "always"
-      ]
+      "import/no-unresolved": "off",
+      "import/extensions": "off"
     }
   },
   "licenses": [
@@ -125,3 +66,4 @@
   ],
   "dependencies": {}
 }
+

--- a/exercises/series/package.json
+++ b/exercises/series/package.json
@@ -10,9 +10,13 @@
   },
   "devDependencies": {
     "babel-jest": "^20.0.1",
-    "babel-preset-env": "^1.4.0",
     "babel-plugin-transform-builtin-extend": "^1.1.2",
+    "babel-preset-env": "^1.4.0",
     "eslint": "^3.19.0",
+    "eslint-config-airbnb": "^15.0.1",
+    "eslint-plugin-import": "^2.2.0",
+    "eslint-plugin-jsx-a11y": "^5.0.1",
+    "eslint-plugin-react": "^7.0.1",
     "jest": "^20.0.1"
   },
   "jest": {
@@ -49,75 +53,12 @@
     "env": {
       "es6": true,
       "node": true,
-      "jasmine": true
+      "jest": true
     },
-    "extends": "eslint:recommended",
+    "extends": "airbnb",
     "rules": {
-      "indent": [
-        "off",
-        2
-      ],
-      "block-scoped-var": "off",
-      "radix": "off",
-      "no-use-before-define": "off",
-      "one-var": [
-        "off",
-        "always"
-      ],
-      "quotes": [
-        "off",
-        "single",
-        {
-          "avoidEscape": true
-        }
-      ],
-      "semi": [
-        "off",
-        "always"
-      ],
-      "semi-spacing": [
-        "off",
-        {
-          "before": false,
-          "after": true
-        }
-      ],
-      "no-whitespace-before-property": "off",
-      "space-before-blocks": [
-        "off",
-        "always"
-      ],
-      "space-before-function-paren": [
-        "off",
-        {
-          "anonymous": "always",
-          "named": "never"
-        }
-      ],
-      "keyword-spacing": [
-        "off",
-        {
-          "before": true,
-          "after": true
-        }
-      ],
-      "no-multi-spaces": "off",
-      "no-trailing-spaces": "off",
-      "curly": [
-        "error",
-        "all"
-      ],
-      "brace-style": [
-        "error",
-        "1tbs",
-        {
-          "allowSingleLine": true
-        }
-      ],
-      "object-curly-spacing": [
-        "off",
-        "always"
-      ]
+      "import/no-unresolved": "off",
+      "import/extensions": "off"
     }
   },
   "licenses": [
@@ -125,3 +66,4 @@
   ],
   "dependencies": {}
 }
+

--- a/exercises/sieve/package.json
+++ b/exercises/sieve/package.json
@@ -10,9 +10,13 @@
   },
   "devDependencies": {
     "babel-jest": "^20.0.1",
-    "babel-preset-env": "^1.4.0",
     "babel-plugin-transform-builtin-extend": "^1.1.2",
+    "babel-preset-env": "^1.4.0",
     "eslint": "^3.19.0",
+    "eslint-config-airbnb": "^15.0.1",
+    "eslint-plugin-import": "^2.2.0",
+    "eslint-plugin-jsx-a11y": "^5.0.1",
+    "eslint-plugin-react": "^7.0.1",
     "jest": "^20.0.1"
   },
   "jest": {
@@ -49,75 +53,12 @@
     "env": {
       "es6": true,
       "node": true,
-      "jasmine": true
+      "jest": true
     },
-    "extends": "eslint:recommended",
+    "extends": "airbnb",
     "rules": {
-      "indent": [
-        "off",
-        2
-      ],
-      "block-scoped-var": "off",
-      "radix": "off",
-      "no-use-before-define": "off",
-      "one-var": [
-        "off",
-        "always"
-      ],
-      "quotes": [
-        "off",
-        "single",
-        {
-          "avoidEscape": true
-        }
-      ],
-      "semi": [
-        "off",
-        "always"
-      ],
-      "semi-spacing": [
-        "off",
-        {
-          "before": false,
-          "after": true
-        }
-      ],
-      "no-whitespace-before-property": "off",
-      "space-before-blocks": [
-        "off",
-        "always"
-      ],
-      "space-before-function-paren": [
-        "off",
-        {
-          "anonymous": "always",
-          "named": "never"
-        }
-      ],
-      "keyword-spacing": [
-        "off",
-        {
-          "before": true,
-          "after": true
-        }
-      ],
-      "no-multi-spaces": "off",
-      "no-trailing-spaces": "off",
-      "curly": [
-        "error",
-        "all"
-      ],
-      "brace-style": [
-        "error",
-        "1tbs",
-        {
-          "allowSingleLine": true
-        }
-      ],
-      "object-curly-spacing": [
-        "off",
-        "always"
-      ]
+      "import/no-unresolved": "off",
+      "import/extensions": "off"
     }
   },
   "licenses": [
@@ -125,3 +66,4 @@
   ],
   "dependencies": {}
 }
+

--- a/exercises/simple-cipher/package.json
+++ b/exercises/simple-cipher/package.json
@@ -10,9 +10,13 @@
   },
   "devDependencies": {
     "babel-jest": "^20.0.1",
-    "babel-preset-env": "^1.4.0",
     "babel-plugin-transform-builtin-extend": "^1.1.2",
+    "babel-preset-env": "^1.4.0",
     "eslint": "^3.19.0",
+    "eslint-config-airbnb": "^15.0.1",
+    "eslint-plugin-import": "^2.2.0",
+    "eslint-plugin-jsx-a11y": "^5.0.1",
+    "eslint-plugin-react": "^7.0.1",
     "jest": "^20.0.1"
   },
   "jest": {
@@ -49,75 +53,12 @@
     "env": {
       "es6": true,
       "node": true,
-      "jasmine": true
+      "jest": true
     },
-    "extends": "eslint:recommended",
+    "extends": "airbnb",
     "rules": {
-      "indent": [
-        "off",
-        2
-      ],
-      "block-scoped-var": "off",
-      "radix": "off",
-      "no-use-before-define": "off",
-      "one-var": [
-        "off",
-        "always"
-      ],
-      "quotes": [
-        "off",
-        "single",
-        {
-          "avoidEscape": true
-        }
-      ],
-      "semi": [
-        "off",
-        "always"
-      ],
-      "semi-spacing": [
-        "off",
-        {
-          "before": false,
-          "after": true
-        }
-      ],
-      "no-whitespace-before-property": "off",
-      "space-before-blocks": [
-        "off",
-        "always"
-      ],
-      "space-before-function-paren": [
-        "off",
-        {
-          "anonymous": "always",
-          "named": "never"
-        }
-      ],
-      "keyword-spacing": [
-        "off",
-        {
-          "before": true,
-          "after": true
-        }
-      ],
-      "no-multi-spaces": "off",
-      "no-trailing-spaces": "off",
-      "curly": [
-        "error",
-        "all"
-      ],
-      "brace-style": [
-        "error",
-        "1tbs",
-        {
-          "allowSingleLine": true
-        }
-      ],
-      "object-curly-spacing": [
-        "off",
-        "always"
-      ]
+      "import/no-unresolved": "off",
+      "import/extensions": "off"
     }
   },
   "licenses": [
@@ -125,3 +66,4 @@
   ],
   "dependencies": {}
 }
+

--- a/exercises/space-age/package.json
+++ b/exercises/space-age/package.json
@@ -10,9 +10,13 @@
   },
   "devDependencies": {
     "babel-jest": "^20.0.1",
-    "babel-preset-env": "^1.4.0",
     "babel-plugin-transform-builtin-extend": "^1.1.2",
+    "babel-preset-env": "^1.4.0",
     "eslint": "^3.19.0",
+    "eslint-config-airbnb": "^15.0.1",
+    "eslint-plugin-import": "^2.2.0",
+    "eslint-plugin-jsx-a11y": "^5.0.1",
+    "eslint-plugin-react": "^7.0.1",
     "jest": "^20.0.1"
   },
   "jest": {
@@ -49,75 +53,12 @@
     "env": {
       "es6": true,
       "node": true,
-      "jasmine": true
+      "jest": true
     },
-    "extends": "eslint:recommended",
+    "extends": "airbnb",
     "rules": {
-      "indent": [
-        "off",
-        2
-      ],
-      "block-scoped-var": "off",
-      "radix": "off",
-      "no-use-before-define": "off",
-      "one-var": [
-        "off",
-        "always"
-      ],
-      "quotes": [
-        "off",
-        "single",
-        {
-          "avoidEscape": true
-        }
-      ],
-      "semi": [
-        "off",
-        "always"
-      ],
-      "semi-spacing": [
-        "off",
-        {
-          "before": false,
-          "after": true
-        }
-      ],
-      "no-whitespace-before-property": "off",
-      "space-before-blocks": [
-        "off",
-        "always"
-      ],
-      "space-before-function-paren": [
-        "off",
-        {
-          "anonymous": "always",
-          "named": "never"
-        }
-      ],
-      "keyword-spacing": [
-        "off",
-        {
-          "before": true,
-          "after": true
-        }
-      ],
-      "no-multi-spaces": "off",
-      "no-trailing-spaces": "off",
-      "curly": [
-        "error",
-        "all"
-      ],
-      "brace-style": [
-        "error",
-        "1tbs",
-        {
-          "allowSingleLine": true
-        }
-      ],
-      "object-curly-spacing": [
-        "off",
-        "always"
-      ]
+      "import/no-unresolved": "off",
+      "import/extensions": "off"
     }
   },
   "licenses": [
@@ -125,3 +66,4 @@
   ],
   "dependencies": {}
 }
+

--- a/exercises/strain/package.json
+++ b/exercises/strain/package.json
@@ -10,9 +10,13 @@
   },
   "devDependencies": {
     "babel-jest": "^20.0.1",
-    "babel-preset-env": "^1.4.0",
     "babel-plugin-transform-builtin-extend": "^1.1.2",
+    "babel-preset-env": "^1.4.0",
     "eslint": "^3.19.0",
+    "eslint-config-airbnb": "^15.0.1",
+    "eslint-plugin-import": "^2.2.0",
+    "eslint-plugin-jsx-a11y": "^5.0.1",
+    "eslint-plugin-react": "^7.0.1",
     "jest": "^20.0.1"
   },
   "jest": {
@@ -49,75 +53,12 @@
     "env": {
       "es6": true,
       "node": true,
-      "jasmine": true
+      "jest": true
     },
-    "extends": "eslint:recommended",
+    "extends": "airbnb",
     "rules": {
-      "indent": [
-        "off",
-        2
-      ],
-      "block-scoped-var": "off",
-      "radix": "off",
-      "no-use-before-define": "off",
-      "one-var": [
-        "off",
-        "always"
-      ],
-      "quotes": [
-        "off",
-        "single",
-        {
-          "avoidEscape": true
-        }
-      ],
-      "semi": [
-        "off",
-        "always"
-      ],
-      "semi-spacing": [
-        "off",
-        {
-          "before": false,
-          "after": true
-        }
-      ],
-      "no-whitespace-before-property": "off",
-      "space-before-blocks": [
-        "off",
-        "always"
-      ],
-      "space-before-function-paren": [
-        "off",
-        {
-          "anonymous": "always",
-          "named": "never"
-        }
-      ],
-      "keyword-spacing": [
-        "off",
-        {
-          "before": true,
-          "after": true
-        }
-      ],
-      "no-multi-spaces": "off",
-      "no-trailing-spaces": "off",
-      "curly": [
-        "error",
-        "all"
-      ],
-      "brace-style": [
-        "error",
-        "1tbs",
-        {
-          "allowSingleLine": true
-        }
-      ],
-      "object-curly-spacing": [
-        "off",
-        "always"
-      ]
+      "import/no-unresolved": "off",
+      "import/extensions": "off"
     }
   },
   "licenses": [
@@ -125,3 +66,4 @@
   ],
   "dependencies": {}
 }
+

--- a/exercises/sum-of-multiples/package.json
+++ b/exercises/sum-of-multiples/package.json
@@ -10,9 +10,13 @@
   },
   "devDependencies": {
     "babel-jest": "^20.0.1",
-    "babel-preset-env": "^1.4.0",
     "babel-plugin-transform-builtin-extend": "^1.1.2",
+    "babel-preset-env": "^1.4.0",
     "eslint": "^3.19.0",
+    "eslint-config-airbnb": "^15.0.1",
+    "eslint-plugin-import": "^2.2.0",
+    "eslint-plugin-jsx-a11y": "^5.0.1",
+    "eslint-plugin-react": "^7.0.1",
     "jest": "^20.0.1"
   },
   "jest": {
@@ -49,75 +53,12 @@
     "env": {
       "es6": true,
       "node": true,
-      "jasmine": true
+      "jest": true
     },
-    "extends": "eslint:recommended",
+    "extends": "airbnb",
     "rules": {
-      "indent": [
-        "off",
-        2
-      ],
-      "block-scoped-var": "off",
-      "radix": "off",
-      "no-use-before-define": "off",
-      "one-var": [
-        "off",
-        "always"
-      ],
-      "quotes": [
-        "off",
-        "single",
-        {
-          "avoidEscape": true
-        }
-      ],
-      "semi": [
-        "off",
-        "always"
-      ],
-      "semi-spacing": [
-        "off",
-        {
-          "before": false,
-          "after": true
-        }
-      ],
-      "no-whitespace-before-property": "off",
-      "space-before-blocks": [
-        "off",
-        "always"
-      ],
-      "space-before-function-paren": [
-        "off",
-        {
-          "anonymous": "always",
-          "named": "never"
-        }
-      ],
-      "keyword-spacing": [
-        "off",
-        {
-          "before": true,
-          "after": true
-        }
-      ],
-      "no-multi-spaces": "off",
-      "no-trailing-spaces": "off",
-      "curly": [
-        "error",
-        "all"
-      ],
-      "brace-style": [
-        "error",
-        "1tbs",
-        {
-          "allowSingleLine": true
-        }
-      ],
-      "object-curly-spacing": [
-        "off",
-        "always"
-      ]
+      "import/no-unresolved": "off",
+      "import/extensions": "off"
     }
   },
   "licenses": [
@@ -125,3 +66,4 @@
   ],
   "dependencies": {}
 }
+

--- a/exercises/triangle/package.json
+++ b/exercises/triangle/package.json
@@ -10,9 +10,13 @@
   },
   "devDependencies": {
     "babel-jest": "^20.0.1",
-    "babel-preset-env": "^1.4.0",
     "babel-plugin-transform-builtin-extend": "^1.1.2",
+    "babel-preset-env": "^1.4.0",
     "eslint": "^3.19.0",
+    "eslint-config-airbnb": "^15.0.1",
+    "eslint-plugin-import": "^2.2.0",
+    "eslint-plugin-jsx-a11y": "^5.0.1",
+    "eslint-plugin-react": "^7.0.1",
     "jest": "^20.0.1"
   },
   "jest": {
@@ -49,75 +53,12 @@
     "env": {
       "es6": true,
       "node": true,
-      "jasmine": true
+      "jest": true
     },
-    "extends": "eslint:recommended",
+    "extends": "airbnb",
     "rules": {
-      "indent": [
-        "off",
-        2
-      ],
-      "block-scoped-var": "off",
-      "radix": "off",
-      "no-use-before-define": "off",
-      "one-var": [
-        "off",
-        "always"
-      ],
-      "quotes": [
-        "off",
-        "single",
-        {
-          "avoidEscape": true
-        }
-      ],
-      "semi": [
-        "off",
-        "always"
-      ],
-      "semi-spacing": [
-        "off",
-        {
-          "before": false,
-          "after": true
-        }
-      ],
-      "no-whitespace-before-property": "off",
-      "space-before-blocks": [
-        "off",
-        "always"
-      ],
-      "space-before-function-paren": [
-        "off",
-        {
-          "anonymous": "always",
-          "named": "never"
-        }
-      ],
-      "keyword-spacing": [
-        "off",
-        {
-          "before": true,
-          "after": true
-        }
-      ],
-      "no-multi-spaces": "off",
-      "no-trailing-spaces": "off",
-      "curly": [
-        "error",
-        "all"
-      ],
-      "brace-style": [
-        "error",
-        "1tbs",
-        {
-          "allowSingleLine": true
-        }
-      ],
-      "object-curly-spacing": [
-        "off",
-        "always"
-      ]
+      "import/no-unresolved": "off",
+      "import/extensions": "off"
     }
   },
   "licenses": [
@@ -125,3 +66,4 @@
   ],
   "dependencies": {}
 }
+

--- a/exercises/trinary/package.json
+++ b/exercises/trinary/package.json
@@ -10,9 +10,13 @@
   },
   "devDependencies": {
     "babel-jest": "^20.0.1",
-    "babel-preset-env": "^1.4.0",
     "babel-plugin-transform-builtin-extend": "^1.1.2",
+    "babel-preset-env": "^1.4.0",
     "eslint": "^3.19.0",
+    "eslint-config-airbnb": "^15.0.1",
+    "eslint-plugin-import": "^2.2.0",
+    "eslint-plugin-jsx-a11y": "^5.0.1",
+    "eslint-plugin-react": "^7.0.1",
     "jest": "^20.0.1"
   },
   "jest": {
@@ -49,75 +53,12 @@
     "env": {
       "es6": true,
       "node": true,
-      "jasmine": true
+      "jest": true
     },
-    "extends": "eslint:recommended",
+    "extends": "airbnb",
     "rules": {
-      "indent": [
-        "off",
-        2
-      ],
-      "block-scoped-var": "off",
-      "radix": "off",
-      "no-use-before-define": "off",
-      "one-var": [
-        "off",
-        "always"
-      ],
-      "quotes": [
-        "off",
-        "single",
-        {
-          "avoidEscape": true
-        }
-      ],
-      "semi": [
-        "off",
-        "always"
-      ],
-      "semi-spacing": [
-        "off",
-        {
-          "before": false,
-          "after": true
-        }
-      ],
-      "no-whitespace-before-property": "off",
-      "space-before-blocks": [
-        "off",
-        "always"
-      ],
-      "space-before-function-paren": [
-        "off",
-        {
-          "anonymous": "always",
-          "named": "never"
-        }
-      ],
-      "keyword-spacing": [
-        "off",
-        {
-          "before": true,
-          "after": true
-        }
-      ],
-      "no-multi-spaces": "off",
-      "no-trailing-spaces": "off",
-      "curly": [
-        "error",
-        "all"
-      ],
-      "brace-style": [
-        "error",
-        "1tbs",
-        {
-          "allowSingleLine": true
-        }
-      ],
-      "object-curly-spacing": [
-        "off",
-        "always"
-      ]
+      "import/no-unresolved": "off",
+      "import/extensions": "off"
     }
   },
   "licenses": [
@@ -125,3 +66,4 @@
   ],
   "dependencies": {}
 }
+

--- a/exercises/two-bucket/package.json
+++ b/exercises/two-bucket/package.json
@@ -10,9 +10,13 @@
   },
   "devDependencies": {
     "babel-jest": "^20.0.1",
-    "babel-preset-env": "^1.4.0",
     "babel-plugin-transform-builtin-extend": "^1.1.2",
+    "babel-preset-env": "^1.4.0",
     "eslint": "^3.19.0",
+    "eslint-config-airbnb": "^15.0.1",
+    "eslint-plugin-import": "^2.2.0",
+    "eslint-plugin-jsx-a11y": "^5.0.1",
+    "eslint-plugin-react": "^7.0.1",
     "jest": "^20.0.1"
   },
   "jest": {
@@ -49,75 +53,12 @@
     "env": {
       "es6": true,
       "node": true,
-      "jasmine": true
+      "jest": true
     },
-    "extends": "eslint:recommended",
+    "extends": "airbnb",
     "rules": {
-      "indent": [
-        "off",
-        2
-      ],
-      "block-scoped-var": "off",
-      "radix": "off",
-      "no-use-before-define": "off",
-      "one-var": [
-        "off",
-        "always"
-      ],
-      "quotes": [
-        "off",
-        "single",
-        {
-          "avoidEscape": true
-        }
-      ],
-      "semi": [
-        "off",
-        "always"
-      ],
-      "semi-spacing": [
-        "off",
-        {
-          "before": false,
-          "after": true
-        }
-      ],
-      "no-whitespace-before-property": "off",
-      "space-before-blocks": [
-        "off",
-        "always"
-      ],
-      "space-before-function-paren": [
-        "off",
-        {
-          "anonymous": "always",
-          "named": "never"
-        }
-      ],
-      "keyword-spacing": [
-        "off",
-        {
-          "before": true,
-          "after": true
-        }
-      ],
-      "no-multi-spaces": "off",
-      "no-trailing-spaces": "off",
-      "curly": [
-        "error",
-        "all"
-      ],
-      "brace-style": [
-        "error",
-        "1tbs",
-        {
-          "allowSingleLine": true
-        }
-      ],
-      "object-curly-spacing": [
-        "off",
-        "always"
-      ]
+      "import/no-unresolved": "off",
+      "import/extensions": "off"
     }
   },
   "licenses": [
@@ -125,3 +66,4 @@
   ],
   "dependencies": {}
 }
+

--- a/exercises/word-count/package.json
+++ b/exercises/word-count/package.json
@@ -10,9 +10,13 @@
   },
   "devDependencies": {
     "babel-jest": "^20.0.1",
-    "babel-preset-env": "^1.4.0",
     "babel-plugin-transform-builtin-extend": "^1.1.2",
+    "babel-preset-env": "^1.4.0",
     "eslint": "^3.19.0",
+    "eslint-config-airbnb": "^15.0.1",
+    "eslint-plugin-import": "^2.2.0",
+    "eslint-plugin-jsx-a11y": "^5.0.1",
+    "eslint-plugin-react": "^7.0.1",
     "jest": "^20.0.1"
   },
   "jest": {
@@ -49,75 +53,12 @@
     "env": {
       "es6": true,
       "node": true,
-      "jasmine": true
+      "jest": true
     },
-    "extends": "eslint:recommended",
+    "extends": "airbnb",
     "rules": {
-      "indent": [
-        "off",
-        2
-      ],
-      "block-scoped-var": "off",
-      "radix": "off",
-      "no-use-before-define": "off",
-      "one-var": [
-        "off",
-        "always"
-      ],
-      "quotes": [
-        "off",
-        "single",
-        {
-          "avoidEscape": true
-        }
-      ],
-      "semi": [
-        "off",
-        "always"
-      ],
-      "semi-spacing": [
-        "off",
-        {
-          "before": false,
-          "after": true
-        }
-      ],
-      "no-whitespace-before-property": "off",
-      "space-before-blocks": [
-        "off",
-        "always"
-      ],
-      "space-before-function-paren": [
-        "off",
-        {
-          "anonymous": "always",
-          "named": "never"
-        }
-      ],
-      "keyword-spacing": [
-        "off",
-        {
-          "before": true,
-          "after": true
-        }
-      ],
-      "no-multi-spaces": "off",
-      "no-trailing-spaces": "off",
-      "curly": [
-        "error",
-        "all"
-      ],
-      "brace-style": [
-        "error",
-        "1tbs",
-        {
-          "allowSingleLine": true
-        }
-      ],
-      "object-curly-spacing": [
-        "off",
-        "always"
-      ]
+      "import/no-unresolved": "off",
+      "import/extensions": "off"
     }
   },
   "licenses": [
@@ -125,3 +66,4 @@
   ],
   "dependencies": {}
 }
+

--- a/exercises/wordy/package.json
+++ b/exercises/wordy/package.json
@@ -10,9 +10,13 @@
   },
   "devDependencies": {
     "babel-jest": "^20.0.1",
-    "babel-preset-env": "^1.4.0",
     "babel-plugin-transform-builtin-extend": "^1.1.2",
+    "babel-preset-env": "^1.4.0",
     "eslint": "^3.19.0",
+    "eslint-config-airbnb": "^15.0.1",
+    "eslint-plugin-import": "^2.2.0",
+    "eslint-plugin-jsx-a11y": "^5.0.1",
+    "eslint-plugin-react": "^7.0.1",
     "jest": "^20.0.1"
   },
   "jest": {
@@ -49,75 +53,12 @@
     "env": {
       "es6": true,
       "node": true,
-      "jasmine": true
+      "jest": true
     },
-    "extends": "eslint:recommended",
+    "extends": "airbnb",
     "rules": {
-      "indent": [
-        "off",
-        2
-      ],
-      "block-scoped-var": "off",
-      "radix": "off",
-      "no-use-before-define": "off",
-      "one-var": [
-        "off",
-        "always"
-      ],
-      "quotes": [
-        "off",
-        "single",
-        {
-          "avoidEscape": true
-        }
-      ],
-      "semi": [
-        "off",
-        "always"
-      ],
-      "semi-spacing": [
-        "off",
-        {
-          "before": false,
-          "after": true
-        }
-      ],
-      "no-whitespace-before-property": "off",
-      "space-before-blocks": [
-        "off",
-        "always"
-      ],
-      "space-before-function-paren": [
-        "off",
-        {
-          "anonymous": "always",
-          "named": "never"
-        }
-      ],
-      "keyword-spacing": [
-        "off",
-        {
-          "before": true,
-          "after": true
-        }
-      ],
-      "no-multi-spaces": "off",
-      "no-trailing-spaces": "off",
-      "curly": [
-        "error",
-        "all"
-      ],
-      "brace-style": [
-        "error",
-        "1tbs",
-        {
-          "allowSingleLine": true
-        }
-      ],
-      "object-curly-spacing": [
-        "off",
-        "always"
-      ]
+      "import/no-unresolved": "off",
+      "import/extensions": "off"
     }
   },
   "licenses": [
@@ -125,3 +66,4 @@
   ],
   "dependencies": {}
 }
+

--- a/package.json
+++ b/package.json
@@ -10,9 +10,13 @@
   },
   "devDependencies": {
     "babel-jest": "^20.0.1",
-    "babel-preset-env": "^1.4.0",
     "babel-plugin-transform-builtin-extend": "^1.1.2",
+    "babel-preset-env": "^1.4.0",
     "eslint": "^3.19.0",
+    "eslint-config-airbnb": "^15.0.1",
+    "eslint-plugin-import": "^2.2.0",
+    "eslint-plugin-jsx-a11y": "^5.0.1",
+    "eslint-plugin-react": "^7.0.1",
     "jest": "^20.0.1"
   },
   "jest": {
@@ -49,75 +53,12 @@
     "env": {
       "es6": true,
       "node": true,
-      "jasmine": true
+      "jest": true
     },
-    "extends": "eslint:recommended",
+    "extends": "airbnb",
     "rules": {
-      "indent": [
-        "off",
-        2
-      ],
-      "block-scoped-var": "off",
-      "radix": "off",
-      "no-use-before-define": "off",
-      "one-var": [
-        "off",
-        "always"
-      ],
-      "quotes": [
-        "off",
-        "single",
-        {
-          "avoidEscape": true
-        }
-      ],
-      "semi": [
-        "off",
-        "always"
-      ],
-      "semi-spacing": [
-        "off",
-        {
-          "before": false,
-          "after": true
-        }
-      ],
-      "no-whitespace-before-property": "off",
-      "space-before-blocks": [
-        "off",
-        "always"
-      ],
-      "space-before-function-paren": [
-        "off",
-        {
-          "anonymous": "always",
-          "named": "never"
-        }
-      ],
-      "keyword-spacing": [
-        "off",
-        {
-          "before": true,
-          "after": true
-        }
-      ],
-      "no-multi-spaces": "off",
-      "no-trailing-spaces": "off",
-      "curly": [
-        "error",
-        "all"
-      ],
-      "brace-style": [
-        "error",
-        "1tbs",
-        {
-          "allowSingleLine": true
-        }
-      ],
-      "object-curly-spacing": [
-        "off",
-        "always"
-      ]
+      "import/no-unresolved": "off",
+      "import/extensions": "off"
     }
   },
   "licenses": [
@@ -125,3 +66,4 @@
   ],
   "dependencies": {}
 }
+


### PR DESCRIPTION
#311 doesn't look like a good approach to introduce Airbnb as code standard.

It requires lots of changes on `package.json` and conflicts happen all the time.

Let's change: this PR just configure airbnb style guid as code standard. No rule is disabled. But there are more than 2000 reported errors. Instead of disabling rules (modifying `package.json` all over the place), we will live with ESLint errors. They can be fixed at exercise level. In theory, there won't be more changes to `package.json` files, just in the two or three files in an exercise. If a conflict arise, it will be in just 2 or 3 files. Not in all `package.json` ones.

But this PR should be merged soon to be able to start working on fixing ESLint errors.