### PR TITLE
Add configuration defaults for nextercism

### DIFF
--- a/config.json
+++ b/config.json
@@ -6,301 +6,430 @@
   "test_pattern": ".*[.]spec[.]js$",
   "exercises": [
     {
+      "uuid": "9ce0f408-6d7b-4466-a390-75aeaf9492f2",
       "slug": "hello-world",
+      "core": false,
+      "unlocked_by": null,
       "difficulty": 1,
       "topics": [
 
       ]
     },
     {
+      "uuid": "7c8294ee-5924-4bf8-a72f-31d0e2d7d9a0",
       "slug": "leap",
+      "core": false,
+      "unlocked_by": null,
       "difficulty": 1,
       "topics": [
 
       ]
     },
     {
+      "uuid": "d773c4ef-c09e-40e4-a7fe-01456cb4a12a",
       "slug": "hamming",
+      "core": false,
+      "unlocked_by": null,
       "difficulty": 1,
       "topics": [
 
       ]
     },
     {
+      "uuid": "342974d6-9083-4754-a6c5-ed1e19e40ec5",
       "slug": "rna-transcription",
+      "core": false,
+      "unlocked_by": null,
       "difficulty": 1,
       "topics": [
 
       ]
     },
     {
+      "uuid": "a5bf36f0-5d3c-41d4-8d54-e37e484e59cd",
       "slug": "bob",
+      "core": false,
+      "unlocked_by": null,
       "difficulty": 1,
       "topics": [
 
       ]
     },
     {
+      "uuid": "fd7b62d4-266b-4e84-a526-bf3d47901216",
       "slug": "gigasecond",
+      "core": false,
+      "unlocked_by": null,
       "difficulty": 1,
       "topics": [
 
       ]
     },
     {
+      "uuid": "c6691fd2-e10d-47df-acbf-3adeac5a2f89",
       "slug": "perfect-numbers",
+      "core": false,
+      "unlocked_by": null,
       "difficulty": 1,
       "topics": [
 
       ]
     },
     {
+      "uuid": "0073ff9a-cd6a-43cf-b8bf-4d5d8117b81b",
       "slug": "word-count",
+      "core": false,
+      "unlocked_by": null,
       "difficulty": 1,
       "topics": [
 
       ]
     },
     {
+      "uuid": "da5b2b34-a1a7-4970-81f9-4665d875398b",
       "slug": "pangram",
+      "core": false,
+      "unlocked_by": null,
       "difficulty": 1,
       "topics": [
 
       ]
     },
     {
+      "uuid": "6573f168-d8fc-4ccf-a864-1a61f432fae1",
       "slug": "beer-song",
+      "core": false,
+      "unlocked_by": null,
       "difficulty": 1,
       "topics": [
 
       ]
     },
     {
+      "uuid": "82775adb-eabe-4d44-91f5-4080b8834a4a",
       "slug": "phone-number",
+      "core": false,
+      "unlocked_by": null,
       "difficulty": 1,
       "topics": [
 
       ]
     },
     {
+      "uuid": "309fa4f1-e03a-4ab2-b371-cdf742501cf7",
       "slug": "anagram",
+      "core": false,
+      "unlocked_by": null,
       "difficulty": 1,
       "topics": [
 
       ]
     },
     {
+      "uuid": "62672dc7-e827-4c2e-a282-d6df45b60bbd",
       "slug": "food-chain",
+      "core": false,
+      "unlocked_by": null,
       "difficulty": 1,
       "topics": [
 
       ]
     },
     {
+      "uuid": "64637322-33bc-401f-8cec-1f9810a41f75",
       "slug": "grade-school",
+      "core": false,
+      "unlocked_by": null,
       "difficulty": 1,
       "topics": [
 
       ]
     },
     {
+      "uuid": "03f4dfea-e6db-4754-b2c8-ca06c8b81ef1",
       "slug": "robot-name",
+      "core": false,
+      "unlocked_by": null,
       "difficulty": 1,
       "topics": [
 
       ]
     },
     {
+      "uuid": "db16804b-0f63-445d-8beb-99e0f7218d66",
       "slug": "etl",
+      "core": false,
+      "unlocked_by": null,
       "difficulty": 1,
       "topics": [
 
       ]
     },
     {
+      "uuid": "d9d757ed-ebe6-4d4a-aa73-f6834221cd54",
       "slug": "space-age",
+      "core": false,
+      "unlocked_by": null,
       "difficulty": 1,
       "topics": [
 
       ]
     },
     {
+      "uuid": "d003975a-9045-4f03-9ad9-c15db584dc13",
       "slug": "grains",
+      "core": false,
+      "unlocked_by": null,
       "difficulty": 1,
       "topics": [
 
       ]
     },
     {
+      "uuid": "ed3ca73a-a0f0-46b8-8013-8b6d20758c8f",
       "slug": "triangle",
+      "core": false,
+      "unlocked_by": null,
       "difficulty": 1,
       "topics": [
 
       ]
     },
     {
+      "uuid": "4e0e2c30-be33-49b6-b196-213888a93a0c",
       "slug": "clock",
+      "core": false,
+      "unlocked_by": null,
       "difficulty": 1,
       "topics": [
 
       ]
     },
     {
+      "uuid": "127eccbd-3009-4a8f-95c1-7d8aeb608550",
       "slug": "diffie-hellman",
+      "core": false,
+      "unlocked_by": null,
       "difficulty": 3,
       "topics": [
         "Cryptography"
       ]
     },
     {
+      "uuid": "440d78d1-9dea-466f-9bd4-935eed067409",
       "slug": "acronym",
+      "core": false,
+      "unlocked_by": null,
       "difficulty": 1,
       "topics": [
 
       ]
     },
     {
+      "uuid": "11771d47-1109-4579-a62b-e0b8e9583485",
       "slug": "scrabble-score",
+      "core": false,
+      "unlocked_by": null,
       "difficulty": 1,
       "topics": [
 
       ]
     },
     {
+      "uuid": "2fc4f834-a51c-42b8-a4d9-5263229e7648",
       "slug": "roman-numerals",
+      "core": false,
+      "unlocked_by": null,
       "difficulty": 1,
       "topics": [
 
       ]
     },
     {
+      "uuid": "bf0b1f95-3425-4345-8a12-3a80d49b49c9",
       "slug": "circular-buffer",
+      "core": false,
+      "unlocked_by": null,
       "difficulty": 1,
       "topics": [
 
       ]
     },
     {
+      "uuid": "f43cdddf-eea8-4c4a-8359-c69e20ff9661",
       "slug": "prime-factors",
+      "core": false,
+      "unlocked_by": null,
       "difficulty": 1,
       "topics": [
 
       ]
     },
     {
+      "uuid": "f77ac2d1-cf3a-497d-bf04-b484a5a9cb37",
       "slug": "raindrops",
+      "core": false,
+      "unlocked_by": null,
       "difficulty": 1,
       "topics": [
 
       ]
     },
     {
+      "uuid": "9d33d21c-e695-427f-9f58-dd9498d61318",
       "slug": "allergies",
+      "core": false,
+      "unlocked_by": null,
       "difficulty": 1,
       "topics": [
 
       ]
     },
     {
+      "uuid": "8407f9d5-7a7e-40c8-aace-a6a8294ae5e9",
       "slug": "strain",
+      "core": false,
+      "unlocked_by": null,
       "difficulty": 1,
       "topics": [
 
       ]
     },
     {
+      "uuid": "a70e6027-eebe-43a1-84a6-763faa736169",
       "slug": "atbash-cipher",
+      "core": false,
+      "unlocked_by": null,
       "difficulty": 1,
       "topics": [
 
       ]
     },
     {
+      "uuid": "6ebe247c-3d11-48b7-8e6f-39f98359d233",
       "slug": "accumulate",
+      "core": false,
+      "unlocked_by": null,
       "difficulty": 1,
       "topics": [
 
       ]
     },
     {
+      "uuid": "4dc30879-a589-4dd3-b7b6-22261f9d1520",
       "slug": "crypto-square",
+      "core": false,
+      "unlocked_by": null,
       "difficulty": 1,
       "topics": [
 
       ]
     },
     {
+      "uuid": "127287d1-ba44-4400-884a-6fe5f72e210f",
       "slug": "sieve",
+      "core": false,
+      "unlocked_by": null,
       "difficulty": 1,
       "topics": [
 
       ]
     },
     {
+      "uuid": "62d60b42-93bc-4de9-90d1-1ca18a847812",
       "slug": "simple-cipher",
+      "core": false,
+      "unlocked_by": null,
       "difficulty": 1,
       "topics": [
 
       ]
     },
     {
+      "uuid": "28872cc9-f1ef-487f-9a79-6bf7983148bf",
       "slug": "luhn",
+      "core": false,
+      "unlocked_by": null,
       "difficulty": 1,
       "topics": [
 
       ]
     },
     {
+      "uuid": "16e25a38-7ce3-4ccd-b2f0-1550b837fe9b",
       "slug": "pig-latin",
+      "core": false,
+      "unlocked_by": null,
       "difficulty": 1,
       "topics": [
 
       ]
     },
     {
+      "uuid": "394755a3-c743-4b85-b9b8-387907f4e32d",
       "slug": "pythagorean-triplet",
+      "core": false,
+      "unlocked_by": null,
       "difficulty": 1,
       "topics": [
 
       ]
     },
     {
+      "uuid": "5178ae53-5364-46c9-bee3-70e6e8a8c2e3",
       "slug": "series",
+      "core": false,
+      "unlocked_by": null,
       "difficulty": 1,
       "topics": [
 
       ]
     },
     {
+      "uuid": "7dfa878c-83a6-48ef-9170-b6633d51d601",
       "slug": "difference-of-squares",
+      "core": false,
+      "unlocked_by": null,
       "difficulty": 1,
       "topics": [
 
       ]
     },
     {
+      "uuid": "74bbc9e3-edc5-41e0-84d7-5b2d98dd8370",
       "slug": "secret-handshake",
+      "core": false,
+      "unlocked_by": null,
       "difficulty": 1,
       "topics": [
 
       ]
     },
     {
+      "uuid": "ec60a578-8889-46a1-b7b8-306dbd8551d5",
       "slug": "linked-list",
+      "core": false,
+      "unlocked_by": null,
       "difficulty": 1,
       "topics": [
 
       ]
     },
     {
+      "uuid": "9131bdb8-2e0f-4526-b113-8a77712e7216",
       "slug": "wordy",
+      "core": false,
+      "unlocked_by": null,
       "difficulty": 1,
       "topics": [
 
       ]
     },
     {
+      "uuid": "1a6c4a3b-d5db-4a5a-b123-66cf085defe6",
       "slug": "flatten-array",
+      "core": false,
+      "unlocked_by": null,
       "difficulty": 5,
       "topics": [
         "Arrays",
@@ -308,28 +437,40 @@
       ]
     },
     {
+      "uuid": "1f84305d-ea76-4fe2-9858-3b53576d683d",
       "slug": "largest-series-product",
+      "core": false,
+      "unlocked_by": null,
       "difficulty": 1,
       "topics": [
 
       ]
     },
     {
+      "uuid": "13444eff-005a-405e-9737-7b64d99c1a61",
       "slug": "kindergarten-garden",
+      "core": false,
+      "unlocked_by": null,
       "difficulty": 1,
       "topics": [
 
       ]
     },
     {
+      "uuid": "7c569e5d-bb00-44b8-8adc-34253790c19b",
       "slug": "binary-search",
+      "core": false,
+      "unlocked_by": null,
       "difficulty": 1,
       "topics": [
 
       ]
     },
     {
+      "uuid": "7d9db056-5398-41b6-af3b-9707f5eb0dbc",
       "slug": "list-ops",
+      "core": false,
+      "unlocked_by": null,
       "difficulty": 5,
       "topics": [
         "Data structures",
@@ -338,139 +479,200 @@
       ]
     },
     {
+      "uuid": "6c4b4e25-c115-4789-9058-d28ab6ca0d26",
       "slug": "binary-search-tree",
+      "core": false,
+      "unlocked_by": null,
       "difficulty": 1,
       "topics": [
 
       ]
     },
     {
+      "uuid": "dd0b5e67-81f6-437e-8334-2ec0dfeb862a",
       "slug": "matrix",
+      "core": false,
+      "unlocked_by": null,
       "difficulty": 1,
       "topics": [
 
       ]
     },
     {
+      "uuid": "5174bd15-eee2-4b53-b3ee-ca3a8c958a31",
       "slug": "robot-simulator",
+      "core": false,
+      "unlocked_by": null,
       "difficulty": 1,
       "topics": [
 
       ]
     },
     {
+      "uuid": "7ce09989-f202-4c3c-8b7e-72cef18808c3",
       "slug": "nth-prime",
+      "core": false,
+      "unlocked_by": null,
       "difficulty": 1,
       "topics": [
 
       ]
     },
     {
+      "uuid": "f6799d10-0210-4c73-ac08-d5cac1a00ff3",
       "slug": "palindrome-products",
+      "core": false,
+      "unlocked_by": null,
       "difficulty": 1,
       "topics": [
 
       ]
     },
     {
+      "uuid": "99493160-4673-402f-acda-62db5378148d",
       "slug": "pascals-triangle",
+      "core": false,
+      "unlocked_by": null,
       "difficulty": 1,
       "topics": [
 
       ]
     },
     {
+      "uuid": "12989bb3-c593-4f68-bea4-e2c5b76bc3c0",
       "slug": "say",
+      "core": false,
+      "unlocked_by": null,
       "difficulty": 1,
       "topics": [
 
       ]
     },
     {
+      "uuid": "75199d72-4cac-49ce-bffb-23fb659c57ae",
       "slug": "custom-set",
+      "core": false,
+      "unlocked_by": null,
       "difficulty": 1,
       "topics": [
 
       ]
     },
     {
+      "uuid": "f7452f71-795b-40b6-847c-67ef4bb9db45",
       "slug": "sum-of-multiples",
+      "core": false,
+      "unlocked_by": null,
       "difficulty": 1,
       "topics": [
 
       ]
     },
     {
+      "uuid": "007a4cd4-7324-4512-8905-ead0c78146f7",
       "slug": "queen-attack",
+      "core": false,
+      "unlocked_by": null,
       "difficulty": 1,
       "topics": [
 
       ]
     },
     {
+      "uuid": "a01aa48c-65c4-4b1f-b3d9-3ec7da2ef754",
       "slug": "saddle-points",
+      "core": false,
+      "unlocked_by": null,
       "difficulty": 1,
       "topics": [
 
       ]
     },
     {
+      "uuid": "24c197ee-d492-4083-8615-629cb4b836b2",
       "slug": "ocr-numbers",
+      "core": false,
+      "unlocked_by": null,
       "difficulty": 1,
       "topics": [
 
       ]
     },
     {
+      "uuid": "98617798-b49d-4d43-9f65-7131ee73d626",
       "slug": "meetup",
+      "core": false,
+      "unlocked_by": null,
       "difficulty": 1,
       "topics": [
 
       ]
     },
     {
+      "uuid": "4d456646-3a9b-4393-9558-6b30e5c1039c",
       "slug": "bracket-push",
+      "core": false,
+      "unlocked_by": null,
       "difficulty": 1,
       "topics": [
 
       ]
     },
     {
+      "uuid": "0bc6b478-40a8-47ab-889b-c403b922f7e5",
       "slug": "two-bucket",
+      "core": false,
+      "unlocked_by": null,
       "difficulty": 1,
       "topics": [
 
       ]
     },
     {
+      "uuid": "6a1eee0e-f8d4-446d-9c52-f31c3700af1b",
       "slug": "diamond",
+      "core": false,
+      "unlocked_by": null,
       "difficulty": 1,
       "topics": [
 
       ]
     },
     {
+      "uuid": "3df577af-2854-40ee-b211-9b608dbbad58",
       "slug": "isogram",
+      "core": false,
+      "unlocked_by": null,
       "difficulty": 1,
       "topics": [
 
       ]
     },
     {
+      "uuid": "d2d3cd13-b06c-4c24-9964-fb1554f70dd4",
       "slug": "all-your-base",
+      "core": false,
+      "unlocked_by": null,
       "difficulty": 1,
       "topics": [
 
       ]
     },
     {
+      "uuid": "2fa2c262-77ae-409b-bfd8-1d643faae772",
       "slug": "connect",
+      "core": false,
+      "unlocked_by": null,
       "difficulty": 7,
       "topics": [
+
       ]
     },
     {
+      "uuid": "8bafe6c4-9154-4037-9070-7f57f91d495a",
       "slug": "minesweeper",
+      "core": false,
+      "unlocked_by": null,
       "difficulty": 7,
       "topics": [
         "games",
@@ -480,21 +682,36 @@
       ]
     },
     {
+      "uuid": "a602bd33-69fc-4b67-a3d3-95198853095e",
       "slug": "alphametics",
+      "core": false,
+      "unlocked_by": null,
       "difficulty": 7,
       "topics": [
         "games",
         "algorithms"
       ]
+    },
+    {
+      "uuid": "0ba4d3b9-2519-49ac-bd93-f960aca6c11f",
+      "slug": "binary",
+      "deprecated": true
+    },
+    {
+      "uuid": "1acf1d2d-a25e-4576-94de-0470abc872d9",
+      "slug": "trinary",
+      "deprecated": true
+    },
+    {
+      "uuid": "8ed2c9fe-a13f-4313-abf9-125f351c85c9",
+      "slug": "hexadecimal",
+      "deprecated": true
+    },
+    {
+      "uuid": "dec66f89-39d0-4857-9679-a035cf4259d7",
+      "slug": "octal",
+      "deprecated": true
     }
-  ],
-  "deprecated": [
-    "nucleotide-count",
-    "point-mutations",
-    "binary",
-    "trinary",
-    "hexadecimal",
-    "octal"
   ],
   "foregone": [
 


### PR DESCRIPTION
We will be moving to a tree-shaped track rather than a linear one, as described in the [progression & learning in Exercism](https://github.com/exercism/docs/blob/master/about/conception/progression.md) design document.

In order to support this, we need to expand the metadata that exercises are configured with.

Note that 'core' exercises are never unlocked by any other exercises. Core exercises appear in the track in the order that they are listed in the array.

Non-core exercises depend on only one exercise (unlocked_by: ). At the moment we are assuming that this is a core exercise, but there is no reason that it needs to be.

Until now we have operated with a separate deprecated array. These are now being moved into the exercises array with a deprecated field.

With these defaults the track in nextercism will have no core exercises, and all the exercises will be available as 'extras' from the start.

If you haven't already, now would be a good time to do the following:

* add a rough estimate of difficulty to each exercise (scale: 1-10)
* add topics to each exercise
* choose *at most 20 exercises* to be core exercises (set core: true, and delete the unlocked_by key)
* for each exercise that is not core, decide which exercise is the prerequisite (max 1)

If possible, leave 3 or 4 simple exercises as (core: false, unlocked_by: null), as this will provide new participants with some exercises that they can tackle even if they have not finished the first core exercise.


See https://github.com/exercism/meta/issues/16