### PR TITLE
Run Jest only once on Travis for faster builds

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,3 +1,0 @@
-{
-  "plugins": ["transform-regenerator"]
-}

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,4 +6,5 @@ sudo: false
 script:
 - bin/fetch-configlet
 - bin/configlet lint .
-- make test
+- make test-travis
+

--- a/exercises/accumulate/package.json
+++ b/exercises/accumulate/package.json
@@ -9,7 +9,7 @@
     "url": "https://github.com/exercism/xecmascript"
   },
   "devDependencies": {
-    "babel-jest": "^20.0.1",
+    "babel-jest": "^20.0.3",
     "babel-plugin-transform-builtin-extend": "^1.1.2",
     "babel-preset-env": "^1.4.0",
     "eslint": "^3.19.0",
@@ -17,7 +17,7 @@
     "eslint-plugin-import": "^2.2.0",
     "eslint-plugin-jsx-a11y": "^5.0.1",
     "eslint-plugin-react": "^7.0.1",
-    "jest": "^20.0.1"
+    "jest": "^20.0.4"
   },
   "jest": {
     "modulePathIgnorePatterns": [
@@ -36,9 +36,10 @@
             "Error"
           ]
         }
-      ]
+      ],
+      ["transform-regenerator"]
     ]
-  },
+},
   "scripts": {
     "test": "jest --no-cache ./*",
     "watch": "jest --no-cache --watch ./*",
@@ -66,4 +67,3 @@
   ],
   "dependencies": {}
 }
-

--- a/exercises/acronym/package.json
+++ b/exercises/acronym/package.json
@@ -9,7 +9,7 @@
     "url": "https://github.com/exercism/xecmascript"
   },
   "devDependencies": {
-    "babel-jest": "^20.0.1",
+    "babel-jest": "^20.0.3",
     "babel-plugin-transform-builtin-extend": "^1.1.2",
     "babel-preset-env": "^1.4.0",
     "eslint": "^3.19.0",
@@ -17,7 +17,7 @@
     "eslint-plugin-import": "^2.2.0",
     "eslint-plugin-jsx-a11y": "^5.0.1",
     "eslint-plugin-react": "^7.0.1",
-    "jest": "^20.0.1"
+    "jest": "^20.0.4"
   },
   "jest": {
     "modulePathIgnorePatterns": [
@@ -36,9 +36,10 @@
             "Error"
           ]
         }
-      ]
+      ],
+      ["transform-regenerator"]
     ]
-  },
+},
   "scripts": {
     "test": "jest --no-cache ./*",
     "watch": "jest --no-cache --watch ./*",
@@ -66,4 +67,3 @@
   ],
   "dependencies": {}
 }
-

--- a/exercises/all-your-base/package.json
+++ b/exercises/all-your-base/package.json
@@ -9,7 +9,7 @@
     "url": "https://github.com/exercism/xecmascript"
   },
   "devDependencies": {
-    "babel-jest": "^20.0.1",
+    "babel-jest": "^20.0.3",
     "babel-plugin-transform-builtin-extend": "^1.1.2",
     "babel-preset-env": "^1.4.0",
     "eslint": "^3.19.0",
@@ -17,7 +17,7 @@
     "eslint-plugin-import": "^2.2.0",
     "eslint-plugin-jsx-a11y": "^5.0.1",
     "eslint-plugin-react": "^7.0.1",
-    "jest": "^20.0.1"
+    "jest": "^20.0.4"
   },
   "jest": {
     "modulePathIgnorePatterns": [
@@ -36,9 +36,10 @@
             "Error"
           ]
         }
-      ]
+      ],
+      ["transform-regenerator"]
     ]
-  },
+},
   "scripts": {
     "test": "jest --no-cache ./*",
     "watch": "jest --no-cache --watch ./*",
@@ -66,4 +67,3 @@
   ],
   "dependencies": {}
 }
-

--- a/exercises/allergies/package.json
+++ b/exercises/allergies/package.json
@@ -9,7 +9,7 @@
     "url": "https://github.com/exercism/xecmascript"
   },
   "devDependencies": {
-    "babel-jest": "^20.0.1",
+    "babel-jest": "^20.0.3",
     "babel-plugin-transform-builtin-extend": "^1.1.2",
     "babel-preset-env": "^1.4.0",
     "eslint": "^3.19.0",
@@ -17,7 +17,7 @@
     "eslint-plugin-import": "^2.2.0",
     "eslint-plugin-jsx-a11y": "^5.0.1",
     "eslint-plugin-react": "^7.0.1",
-    "jest": "^20.0.1"
+    "jest": "^20.0.4"
   },
   "jest": {
     "modulePathIgnorePatterns": [
@@ -36,9 +36,10 @@
             "Error"
           ]
         }
-      ]
+      ],
+      ["transform-regenerator"]
     ]
-  },
+},
   "scripts": {
     "test": "jest --no-cache ./*",
     "watch": "jest --no-cache --watch ./*",
@@ -66,4 +67,3 @@
   ],
   "dependencies": {}
 }
-

--- a/exercises/alphametics/package.json
+++ b/exercises/alphametics/package.json
@@ -9,7 +9,7 @@
     "url": "https://github.com/exercism/xecmascript"
   },
   "devDependencies": {
-    "babel-jest": "^20.0.1",
+    "babel-jest": "^20.0.3",
     "babel-plugin-transform-builtin-extend": "^1.1.2",
     "babel-preset-env": "^1.4.0",
     "eslint": "^3.19.0",
@@ -17,7 +17,7 @@
     "eslint-plugin-import": "^2.2.0",
     "eslint-plugin-jsx-a11y": "^5.0.1",
     "eslint-plugin-react": "^7.0.1",
-    "jest": "^20.0.1"
+    "jest": "^20.0.4"
   },
   "jest": {
     "modulePathIgnorePatterns": [
@@ -36,9 +36,10 @@
             "Error"
           ]
         }
-      ]
+      ],
+      ["transform-regenerator"]
     ]
-  },
+},
   "scripts": {
     "test": "jest --no-cache ./*",
     "watch": "jest --no-cache --watch ./*",
@@ -66,4 +67,3 @@
   ],
   "dependencies": {}
 }
-

--- a/exercises/anagram/package.json
+++ b/exercises/anagram/package.json
@@ -9,7 +9,7 @@
     "url": "https://github.com/exercism/xecmascript"
   },
   "devDependencies": {
-    "babel-jest": "^20.0.1",
+    "babel-jest": "^20.0.3",
     "babel-plugin-transform-builtin-extend": "^1.1.2",
     "babel-preset-env": "^1.4.0",
     "eslint": "^3.19.0",
@@ -17,7 +17,7 @@
     "eslint-plugin-import": "^2.2.0",
     "eslint-plugin-jsx-a11y": "^5.0.1",
     "eslint-plugin-react": "^7.0.1",
-    "jest": "^20.0.1"
+    "jest": "^20.0.4"
   },
   "jest": {
     "modulePathIgnorePatterns": [
@@ -36,9 +36,10 @@
             "Error"
           ]
         }
-      ]
+      ],
+      ["transform-regenerator"]
     ]
-  },
+},
   "scripts": {
     "test": "jest --no-cache ./*",
     "watch": "jest --no-cache --watch ./*",
@@ -66,4 +67,3 @@
   ],
   "dependencies": {}
 }
-

--- a/exercises/atbash-cipher/package.json
+++ b/exercises/atbash-cipher/package.json
@@ -9,7 +9,7 @@
     "url": "https://github.com/exercism/xecmascript"
   },
   "devDependencies": {
-    "babel-jest": "^20.0.1",
+    "babel-jest": "^20.0.3",
     "babel-plugin-transform-builtin-extend": "^1.1.2",
     "babel-preset-env": "^1.4.0",
     "eslint": "^3.19.0",
@@ -17,7 +17,7 @@
     "eslint-plugin-import": "^2.2.0",
     "eslint-plugin-jsx-a11y": "^5.0.1",
     "eslint-plugin-react": "^7.0.1",
-    "jest": "^20.0.1"
+    "jest": "^20.0.4"
   },
   "jest": {
     "modulePathIgnorePatterns": [
@@ -36,9 +36,10 @@
             "Error"
           ]
         }
-      ]
+      ],
+      ["transform-regenerator"]
     ]
-  },
+},
   "scripts": {
     "test": "jest --no-cache ./*",
     "watch": "jest --no-cache --watch ./*",
@@ -66,4 +67,3 @@
   ],
   "dependencies": {}
 }
-

--- a/exercises/beer-song/package.json
+++ b/exercises/beer-song/package.json
@@ -9,7 +9,7 @@
     "url": "https://github.com/exercism/xecmascript"
   },
   "devDependencies": {
-    "babel-jest": "^20.0.1",
+    "babel-jest": "^20.0.3",
     "babel-plugin-transform-builtin-extend": "^1.1.2",
     "babel-preset-env": "^1.4.0",
     "eslint": "^3.19.0",
@@ -17,7 +17,7 @@
     "eslint-plugin-import": "^2.2.0",
     "eslint-plugin-jsx-a11y": "^5.0.1",
     "eslint-plugin-react": "^7.0.1",
-    "jest": "^20.0.1"
+    "jest": "^20.0.4"
   },
   "jest": {
     "modulePathIgnorePatterns": [
@@ -36,9 +36,10 @@
             "Error"
           ]
         }
-      ]
+      ],
+      ["transform-regenerator"]
     ]
-  },
+},
   "scripts": {
     "test": "jest --no-cache ./*",
     "watch": "jest --no-cache --watch ./*",
@@ -66,4 +67,3 @@
   ],
   "dependencies": {}
 }
-

--- a/exercises/binary-search-tree/package.json
+++ b/exercises/binary-search-tree/package.json
@@ -9,7 +9,7 @@
     "url": "https://github.com/exercism/xecmascript"
   },
   "devDependencies": {
-    "babel-jest": "^20.0.1",
+    "babel-jest": "^20.0.3",
     "babel-plugin-transform-builtin-extend": "^1.1.2",
     "babel-preset-env": "^1.4.0",
     "eslint": "^3.19.0",
@@ -17,7 +17,7 @@
     "eslint-plugin-import": "^2.2.0",
     "eslint-plugin-jsx-a11y": "^5.0.1",
     "eslint-plugin-react": "^7.0.1",
-    "jest": "^20.0.1"
+    "jest": "^20.0.4"
   },
   "jest": {
     "modulePathIgnorePatterns": [
@@ -36,9 +36,10 @@
             "Error"
           ]
         }
-      ]
+      ],
+      ["transform-regenerator"]
     ]
-  },
+},
   "scripts": {
     "test": "jest --no-cache ./*",
     "watch": "jest --no-cache --watch ./*",
@@ -66,4 +67,3 @@
   ],
   "dependencies": {}
 }
-

--- a/exercises/binary-search/package.json
+++ b/exercises/binary-search/package.json
@@ -9,7 +9,7 @@
     "url": "https://github.com/exercism/xecmascript"
   },
   "devDependencies": {
-    "babel-jest": "^20.0.1",
+    "babel-jest": "^20.0.3",
     "babel-plugin-transform-builtin-extend": "^1.1.2",
     "babel-preset-env": "^1.4.0",
     "eslint": "^3.19.0",
@@ -17,7 +17,7 @@
     "eslint-plugin-import": "^2.2.0",
     "eslint-plugin-jsx-a11y": "^5.0.1",
     "eslint-plugin-react": "^7.0.1",
-    "jest": "^20.0.1"
+    "jest": "^20.0.4"
   },
   "jest": {
     "modulePathIgnorePatterns": [
@@ -36,9 +36,10 @@
             "Error"
           ]
         }
-      ]
+      ],
+      ["transform-regenerator"]
     ]
-  },
+},
   "scripts": {
     "test": "jest --no-cache ./*",
     "watch": "jest --no-cache --watch ./*",
@@ -66,4 +67,3 @@
   ],
   "dependencies": {}
 }
-

--- a/exercises/binary/package.json
+++ b/exercises/binary/package.json
@@ -9,7 +9,7 @@
     "url": "https://github.com/exercism/xecmascript"
   },
   "devDependencies": {
-    "babel-jest": "^20.0.1",
+    "babel-jest": "^20.0.3",
     "babel-plugin-transform-builtin-extend": "^1.1.2",
     "babel-preset-env": "^1.4.0",
     "eslint": "^3.19.0",
@@ -17,7 +17,7 @@
     "eslint-plugin-import": "^2.2.0",
     "eslint-plugin-jsx-a11y": "^5.0.1",
     "eslint-plugin-react": "^7.0.1",
-    "jest": "^20.0.1"
+    "jest": "^20.0.4"
   },
   "jest": {
     "modulePathIgnorePatterns": [
@@ -36,9 +36,10 @@
             "Error"
           ]
         }
-      ]
+      ],
+      ["transform-regenerator"]
     ]
-  },
+},
   "scripts": {
     "test": "jest --no-cache ./*",
     "watch": "jest --no-cache --watch ./*",
@@ -66,4 +67,3 @@
   ],
   "dependencies": {}
 }
-

--- a/exercises/bob/package.json
+++ b/exercises/bob/package.json
@@ -9,7 +9,7 @@
     "url": "https://github.com/exercism/xecmascript"
   },
   "devDependencies": {
-    "babel-jest": "^20.0.1",
+    "babel-jest": "^20.0.3",
     "babel-plugin-transform-builtin-extend": "^1.1.2",
     "babel-preset-env": "^1.4.0",
     "eslint": "^3.19.0",
@@ -17,7 +17,7 @@
     "eslint-plugin-import": "^2.2.0",
     "eslint-plugin-jsx-a11y": "^5.0.1",
     "eslint-plugin-react": "^7.0.1",
-    "jest": "^20.0.1"
+    "jest": "^20.0.4"
   },
   "jest": {
     "modulePathIgnorePatterns": [
@@ -36,9 +36,10 @@
             "Error"
           ]
         }
-      ]
+      ],
+      ["transform-regenerator"]
     ]
-  },
+},
   "scripts": {
     "test": "jest --no-cache ./*",
     "watch": "jest --no-cache --watch ./*",
@@ -66,4 +67,3 @@
   ],
   "dependencies": {}
 }
-

--- a/exercises/bracket-push/package.json
+++ b/exercises/bracket-push/package.json
@@ -9,7 +9,7 @@
     "url": "https://github.com/exercism/xecmascript"
   },
   "devDependencies": {
-    "babel-jest": "^20.0.1",
+    "babel-jest": "^20.0.3",
     "babel-plugin-transform-builtin-extend": "^1.1.2",
     "babel-preset-env": "^1.4.0",
     "eslint": "^3.19.0",
@@ -17,7 +17,7 @@
     "eslint-plugin-import": "^2.2.0",
     "eslint-plugin-jsx-a11y": "^5.0.1",
     "eslint-plugin-react": "^7.0.1",
-    "jest": "^20.0.1"
+    "jest": "^20.0.4"
   },
   "jest": {
     "modulePathIgnorePatterns": [
@@ -36,9 +36,10 @@
             "Error"
           ]
         }
-      ]
+      ],
+      ["transform-regenerator"]
     ]
-  },
+},
   "scripts": {
     "test": "jest --no-cache ./*",
     "watch": "jest --no-cache --watch ./*",
@@ -66,4 +67,3 @@
   ],
   "dependencies": {}
 }
-

--- a/exercises/circular-buffer/package.json
+++ b/exercises/circular-buffer/package.json
@@ -9,7 +9,7 @@
     "url": "https://github.com/exercism/xecmascript"
   },
   "devDependencies": {
-    "babel-jest": "^20.0.1",
+    "babel-jest": "^20.0.3",
     "babel-plugin-transform-builtin-extend": "^1.1.2",
     "babel-preset-env": "^1.4.0",
     "eslint": "^3.19.0",
@@ -17,7 +17,7 @@
     "eslint-plugin-import": "^2.2.0",
     "eslint-plugin-jsx-a11y": "^5.0.1",
     "eslint-plugin-react": "^7.0.1",
-    "jest": "^20.0.1"
+    "jest": "^20.0.4"
   },
   "jest": {
     "modulePathIgnorePatterns": [
@@ -36,9 +36,10 @@
             "Error"
           ]
         }
-      ]
+      ],
+      ["transform-regenerator"]
     ]
-  },
+},
   "scripts": {
     "test": "jest --no-cache ./*",
     "watch": "jest --no-cache --watch ./*",
@@ -66,4 +67,3 @@
   ],
   "dependencies": {}
 }
-

--- a/exercises/clock/package.json
+++ b/exercises/clock/package.json
@@ -9,7 +9,7 @@
     "url": "https://github.com/exercism/xecmascript"
   },
   "devDependencies": {
-    "babel-jest": "^20.0.1",
+    "babel-jest": "^20.0.3",
     "babel-plugin-transform-builtin-extend": "^1.1.2",
     "babel-preset-env": "^1.4.0",
     "eslint": "^3.19.0",
@@ -17,7 +17,7 @@
     "eslint-plugin-import": "^2.2.0",
     "eslint-plugin-jsx-a11y": "^5.0.1",
     "eslint-plugin-react": "^7.0.1",
-    "jest": "^20.0.1"
+    "jest": "^20.0.4"
   },
   "jest": {
     "modulePathIgnorePatterns": [
@@ -36,9 +36,10 @@
             "Error"
           ]
         }
-      ]
+      ],
+      ["transform-regenerator"]
     ]
-  },
+},
   "scripts": {
     "test": "jest --no-cache ./*",
     "watch": "jest --no-cache --watch ./*",
@@ -66,4 +67,3 @@
   ],
   "dependencies": {}
 }
-

--- a/exercises/connect/package.json
+++ b/exercises/connect/package.json
@@ -9,7 +9,7 @@
     "url": "https://github.com/exercism/xecmascript"
   },
   "devDependencies": {
-    "babel-jest": "^20.0.1",
+    "babel-jest": "^20.0.3",
     "babel-plugin-transform-builtin-extend": "^1.1.2",
     "babel-preset-env": "^1.4.0",
     "eslint": "^3.19.0",
@@ -17,7 +17,7 @@
     "eslint-plugin-import": "^2.2.0",
     "eslint-plugin-jsx-a11y": "^5.0.1",
     "eslint-plugin-react": "^7.0.1",
-    "jest": "^20.0.1"
+    "jest": "^20.0.4"
   },
   "jest": {
     "modulePathIgnorePatterns": [
@@ -36,9 +36,10 @@
             "Error"
           ]
         }
-      ]
+      ],
+      ["transform-regenerator"]
     ]
-  },
+},
   "scripts": {
     "test": "jest --no-cache ./*",
     "watch": "jest --no-cache --watch ./*",
@@ -66,4 +67,3 @@
   ],
   "dependencies": {}
 }
-

--- a/exercises/crypto-square/package.json
+++ b/exercises/crypto-square/package.json
@@ -9,7 +9,7 @@
     "url": "https://github.com/exercism/xecmascript"
   },
   "devDependencies": {
-    "babel-jest": "^20.0.1",
+    "babel-jest": "^20.0.3",
     "babel-plugin-transform-builtin-extend": "^1.1.2",
     "babel-preset-env": "^1.4.0",
     "eslint": "^3.19.0",
@@ -17,7 +17,7 @@
     "eslint-plugin-import": "^2.2.0",
     "eslint-plugin-jsx-a11y": "^5.0.1",
     "eslint-plugin-react": "^7.0.1",
-    "jest": "^20.0.1"
+    "jest": "^20.0.4"
   },
   "jest": {
     "modulePathIgnorePatterns": [
@@ -36,9 +36,10 @@
             "Error"
           ]
         }
-      ]
+      ],
+      ["transform-regenerator"]
     ]
-  },
+},
   "scripts": {
     "test": "jest --no-cache ./*",
     "watch": "jest --no-cache --watch ./*",
@@ -66,4 +67,3 @@
   ],
   "dependencies": {}
 }
-

--- a/exercises/custom-set/package.json
+++ b/exercises/custom-set/package.json
@@ -9,7 +9,7 @@
     "url": "https://github.com/exercism/xecmascript"
   },
   "devDependencies": {
-    "babel-jest": "^20.0.1",
+    "babel-jest": "^20.0.3",
     "babel-plugin-transform-builtin-extend": "^1.1.2",
     "babel-preset-env": "^1.4.0",
     "eslint": "^3.19.0",
@@ -17,7 +17,7 @@
     "eslint-plugin-import": "^2.2.0",
     "eslint-plugin-jsx-a11y": "^5.0.1",
     "eslint-plugin-react": "^7.0.1",
-    "jest": "^20.0.1"
+    "jest": "^20.0.4"
   },
   "jest": {
     "modulePathIgnorePatterns": [
@@ -36,9 +36,10 @@
             "Error"
           ]
         }
-      ]
+      ],
+      ["transform-regenerator"]
     ]
-  },
+},
   "scripts": {
     "test": "jest --no-cache ./*",
     "watch": "jest --no-cache --watch ./*",
@@ -66,4 +67,3 @@
   ],
   "dependencies": {}
 }
-

--- a/exercises/diamond/package.json
+++ b/exercises/diamond/package.json
@@ -9,7 +9,7 @@
     "url": "https://github.com/exercism/xecmascript"
   },
   "devDependencies": {
-    "babel-jest": "^20.0.1",
+    "babel-jest": "^20.0.3",
     "babel-plugin-transform-builtin-extend": "^1.1.2",
     "babel-preset-env": "^1.4.0",
     "eslint": "^3.19.0",
@@ -17,7 +17,7 @@
     "eslint-plugin-import": "^2.2.0",
     "eslint-plugin-jsx-a11y": "^5.0.1",
     "eslint-plugin-react": "^7.0.1",
-    "jest": "^20.0.1"
+    "jest": "^20.0.4"
   },
   "jest": {
     "modulePathIgnorePatterns": [
@@ -36,9 +36,10 @@
             "Error"
           ]
         }
-      ]
+      ],
+      ["transform-regenerator"]
     ]
-  },
+},
   "scripts": {
     "test": "jest --no-cache ./*",
     "watch": "jest --no-cache --watch ./*",
@@ -66,4 +67,3 @@
   ],
   "dependencies": {}
 }
-

--- a/exercises/difference-of-squares/package.json
+++ b/exercises/difference-of-squares/package.json
@@ -9,7 +9,7 @@
     "url": "https://github.com/exercism/xecmascript"
   },
   "devDependencies": {
-    "babel-jest": "^20.0.1",
+    "babel-jest": "^20.0.3",
     "babel-plugin-transform-builtin-extend": "^1.1.2",
     "babel-preset-env": "^1.4.0",
     "eslint": "^3.19.0",
@@ -17,7 +17,7 @@
     "eslint-plugin-import": "^2.2.0",
     "eslint-plugin-jsx-a11y": "^5.0.1",
     "eslint-plugin-react": "^7.0.1",
-    "jest": "^20.0.1"
+    "jest": "^20.0.4"
   },
   "jest": {
     "modulePathIgnorePatterns": [
@@ -36,9 +36,10 @@
             "Error"
           ]
         }
-      ]
+      ],
+      ["transform-regenerator"]
     ]
-  },
+},
   "scripts": {
     "test": "jest --no-cache ./*",
     "watch": "jest --no-cache --watch ./*",
@@ -66,4 +67,3 @@
   ],
   "dependencies": {}
 }
-

--- a/exercises/diffie-hellman/package.json
+++ b/exercises/diffie-hellman/package.json
@@ -9,7 +9,7 @@
     "url": "https://github.com/exercism/xecmascript"
   },
   "devDependencies": {
-    "babel-jest": "^20.0.1",
+    "babel-jest": "^20.0.3",
     "babel-plugin-transform-builtin-extend": "^1.1.2",
     "babel-preset-env": "^1.4.0",
     "eslint": "^3.19.0",
@@ -17,7 +17,7 @@
     "eslint-plugin-import": "^2.2.0",
     "eslint-plugin-jsx-a11y": "^5.0.1",
     "eslint-plugin-react": "^7.0.1",
-    "jest": "^20.0.1"
+    "jest": "^20.0.4"
   },
   "jest": {
     "modulePathIgnorePatterns": [
@@ -36,9 +36,10 @@
             "Error"
           ]
         }
-      ]
+      ],
+      ["transform-regenerator"]
     ]
-  },
+},
   "scripts": {
     "test": "jest --no-cache ./*",
     "watch": "jest --no-cache --watch ./*",
@@ -66,4 +67,3 @@
   ],
   "dependencies": {}
 }
-

--- a/exercises/etl/package.json
+++ b/exercises/etl/package.json
@@ -9,7 +9,7 @@
     "url": "https://github.com/exercism/xecmascript"
   },
   "devDependencies": {
-    "babel-jest": "^20.0.1",
+    "babel-jest": "^20.0.3",
     "babel-plugin-transform-builtin-extend": "^1.1.2",
     "babel-preset-env": "^1.4.0",
     "eslint": "^3.19.0",
@@ -17,7 +17,7 @@
     "eslint-plugin-import": "^2.2.0",
     "eslint-plugin-jsx-a11y": "^5.0.1",
     "eslint-plugin-react": "^7.0.1",
-    "jest": "^20.0.1"
+    "jest": "^20.0.4"
   },
   "jest": {
     "modulePathIgnorePatterns": [
@@ -36,9 +36,10 @@
             "Error"
           ]
         }
-      ]
+      ],
+      ["transform-regenerator"]
     ]
-  },
+},
   "scripts": {
     "test": "jest --no-cache ./*",
     "watch": "jest --no-cache --watch ./*",
@@ -66,4 +67,3 @@
   ],
   "dependencies": {}
 }
-

--- a/exercises/flatten-array/package.json
+++ b/exercises/flatten-array/package.json
@@ -9,7 +9,7 @@
     "url": "https://github.com/exercism/xecmascript"
   },
   "devDependencies": {
-    "babel-jest": "^20.0.1",
+    "babel-jest": "^20.0.3",
     "babel-plugin-transform-builtin-extend": "^1.1.2",
     "babel-preset-env": "^1.4.0",
     "eslint": "^3.19.0",
@@ -17,7 +17,7 @@
     "eslint-plugin-import": "^2.2.0",
     "eslint-plugin-jsx-a11y": "^5.0.1",
     "eslint-plugin-react": "^7.0.1",
-    "jest": "^20.0.1"
+    "jest": "^20.0.4"
   },
   "jest": {
     "modulePathIgnorePatterns": [
@@ -36,9 +36,10 @@
             "Error"
           ]
         }
-      ]
+      ],
+      ["transform-regenerator"]
     ]
-  },
+},
   "scripts": {
     "test": "jest --no-cache ./*",
     "watch": "jest --no-cache --watch ./*",
@@ -66,4 +67,3 @@
   ],
   "dependencies": {}
 }
-

--- a/exercises/food-chain/package.json
+++ b/exercises/food-chain/package.json
@@ -9,7 +9,7 @@
     "url": "https://github.com/exercism/xecmascript"
   },
   "devDependencies": {
-    "babel-jest": "^20.0.1",
+    "babel-jest": "^20.0.3",
     "babel-plugin-transform-builtin-extend": "^1.1.2",
     "babel-preset-env": "^1.4.0",
     "eslint": "^3.19.0",
@@ -17,7 +17,7 @@
     "eslint-plugin-import": "^2.2.0",
     "eslint-plugin-jsx-a11y": "^5.0.1",
     "eslint-plugin-react": "^7.0.1",
-    "jest": "^20.0.1"
+    "jest": "^20.0.4"
   },
   "jest": {
     "modulePathIgnorePatterns": [
@@ -36,9 +36,10 @@
             "Error"
           ]
         }
-      ]
+      ],
+      ["transform-regenerator"]
     ]
-  },
+},
   "scripts": {
     "test": "jest --no-cache ./*",
     "watch": "jest --no-cache --watch ./*",
@@ -66,4 +67,3 @@
   ],
   "dependencies": {}
 }
-

--- a/exercises/gigasecond/package.json
+++ b/exercises/gigasecond/package.json
@@ -9,7 +9,7 @@
     "url": "https://github.com/exercism/xecmascript"
   },
   "devDependencies": {
-    "babel-jest": "^20.0.1",
+    "babel-jest": "^20.0.3",
     "babel-plugin-transform-builtin-extend": "^1.1.2",
     "babel-preset-env": "^1.4.0",
     "eslint": "^3.19.0",
@@ -17,7 +17,7 @@
     "eslint-plugin-import": "^2.2.0",
     "eslint-plugin-jsx-a11y": "^5.0.1",
     "eslint-plugin-react": "^7.0.1",
-    "jest": "^20.0.1"
+    "jest": "^20.0.4"
   },
   "jest": {
     "modulePathIgnorePatterns": [
@@ -36,9 +36,10 @@
             "Error"
           ]
         }
-      ]
+      ],
+      ["transform-regenerator"]
     ]
-  },
+},
   "scripts": {
     "test": "jest --no-cache ./*",
     "watch": "jest --no-cache --watch ./*",
@@ -66,4 +67,3 @@
   ],
   "dependencies": {}
 }
-

--- a/exercises/grade-school/package.json
+++ b/exercises/grade-school/package.json
@@ -9,7 +9,7 @@
     "url": "https://github.com/exercism/xecmascript"
   },
   "devDependencies": {
-    "babel-jest": "^20.0.1",
+    "babel-jest": "^20.0.3",
     "babel-plugin-transform-builtin-extend": "^1.1.2",
     "babel-preset-env": "^1.4.0",
     "eslint": "^3.19.0",
@@ -17,7 +17,7 @@
     "eslint-plugin-import": "^2.2.0",
     "eslint-plugin-jsx-a11y": "^5.0.1",
     "eslint-plugin-react": "^7.0.1",
-    "jest": "^20.0.1"
+    "jest": "^20.0.4"
   },
   "jest": {
     "modulePathIgnorePatterns": [
@@ -36,9 +36,10 @@
             "Error"
           ]
         }
-      ]
+      ],
+      ["transform-regenerator"]
     ]
-  },
+},
   "scripts": {
     "test": "jest --no-cache ./*",
     "watch": "jest --no-cache --watch ./*",
@@ -66,4 +67,3 @@
   ],
   "dependencies": {}
 }
-

--- a/exercises/grains/package.json
+++ b/exercises/grains/package.json
@@ -9,7 +9,7 @@
     "url": "https://github.com/exercism/xecmascript"
   },
   "devDependencies": {
-    "babel-jest": "^20.0.1",
+    "babel-jest": "^20.0.3",
     "babel-plugin-transform-builtin-extend": "^1.1.2",
     "babel-preset-env": "^1.4.0",
     "eslint": "^3.19.0",
@@ -17,7 +17,7 @@
     "eslint-plugin-import": "^2.2.0",
     "eslint-plugin-jsx-a11y": "^5.0.1",
     "eslint-plugin-react": "^7.0.1",
-    "jest": "^20.0.1"
+    "jest": "^20.0.4"
   },
   "jest": {
     "modulePathIgnorePatterns": [
@@ -36,9 +36,10 @@
             "Error"
           ]
         }
-      ]
+      ],
+      ["transform-regenerator"]
     ]
-  },
+},
   "scripts": {
     "test": "jest --no-cache ./*",
     "watch": "jest --no-cache --watch ./*",
@@ -66,4 +67,3 @@
   ],
   "dependencies": {}
 }
-

--- a/exercises/hamming/package.json
+++ b/exercises/hamming/package.json
@@ -9,7 +9,7 @@
     "url": "https://github.com/exercism/xecmascript"
   },
   "devDependencies": {
-    "babel-jest": "^20.0.1",
+    "babel-jest": "^20.0.3",
     "babel-plugin-transform-builtin-extend": "^1.1.2",
     "babel-preset-env": "^1.4.0",
     "eslint": "^3.19.0",
@@ -17,7 +17,7 @@
     "eslint-plugin-import": "^2.2.0",
     "eslint-plugin-jsx-a11y": "^5.0.1",
     "eslint-plugin-react": "^7.0.1",
-    "jest": "^20.0.1"
+    "jest": "^20.0.4"
   },
   "jest": {
     "modulePathIgnorePatterns": [
@@ -36,9 +36,10 @@
             "Error"
           ]
         }
-      ]
+      ],
+      ["transform-regenerator"]
     ]
-  },
+},
   "scripts": {
     "test": "jest --no-cache ./*",
     "watch": "jest --no-cache --watch ./*",
@@ -66,4 +67,3 @@
   ],
   "dependencies": {}
 }
-

--- a/exercises/hello-world/package.json
+++ b/exercises/hello-world/package.json
@@ -9,7 +9,7 @@
     "url": "https://github.com/exercism/xecmascript"
   },
   "devDependencies": {
-    "babel-jest": "^20.0.1",
+    "babel-jest": "^20.0.3",
     "babel-plugin-transform-builtin-extend": "^1.1.2",
     "babel-preset-env": "^1.4.0",
     "eslint": "^3.19.0",
@@ -17,7 +17,7 @@
     "eslint-plugin-import": "^2.2.0",
     "eslint-plugin-jsx-a11y": "^5.0.1",
     "eslint-plugin-react": "^7.0.1",
-    "jest": "^20.0.1"
+    "jest": "^20.0.4"
   },
   "jest": {
     "modulePathIgnorePatterns": [
@@ -36,9 +36,10 @@
             "Error"
           ]
         }
-      ]
+      ],
+      ["transform-regenerator"]
     ]
-  },
+},
   "scripts": {
     "test": "jest --no-cache ./*",
     "watch": "jest --no-cache --watch ./*",
@@ -66,4 +67,3 @@
   ],
   "dependencies": {}
 }
-

--- a/exercises/hexadecimal/package.json
+++ b/exercises/hexadecimal/package.json
@@ -9,7 +9,7 @@
     "url": "https://github.com/exercism/xecmascript"
   },
   "devDependencies": {
-    "babel-jest": "^20.0.1",
+    "babel-jest": "^20.0.3",
     "babel-plugin-transform-builtin-extend": "^1.1.2",
     "babel-preset-env": "^1.4.0",
     "eslint": "^3.19.0",
@@ -17,7 +17,7 @@
     "eslint-plugin-import": "^2.2.0",
     "eslint-plugin-jsx-a11y": "^5.0.1",
     "eslint-plugin-react": "^7.0.1",
-    "jest": "^20.0.1"
+    "jest": "^20.0.4"
   },
   "jest": {
     "modulePathIgnorePatterns": [
@@ -36,9 +36,10 @@
             "Error"
           ]
         }
-      ]
+      ],
+      ["transform-regenerator"]
     ]
-  },
+},
   "scripts": {
     "test": "jest --no-cache ./*",
     "watch": "jest --no-cache --watch ./*",
@@ -66,4 +67,3 @@
   ],
   "dependencies": {}
 }
-

--- a/exercises/isogram/package.json
+++ b/exercises/isogram/package.json
@@ -9,7 +9,7 @@
     "url": "https://github.com/exercism/xecmascript"
   },
   "devDependencies": {
-    "babel-jest": "^20.0.1",
+    "babel-jest": "^20.0.3",
     "babel-plugin-transform-builtin-extend": "^1.1.2",
     "babel-preset-env": "^1.4.0",
     "eslint": "^3.19.0",
@@ -17,7 +17,7 @@
     "eslint-plugin-import": "^2.2.0",
     "eslint-plugin-jsx-a11y": "^5.0.1",
     "eslint-plugin-react": "^7.0.1",
-    "jest": "^20.0.1"
+    "jest": "^20.0.4"
   },
   "jest": {
     "modulePathIgnorePatterns": [
@@ -36,9 +36,10 @@
             "Error"
           ]
         }
-      ]
+      ],
+      ["transform-regenerator"]
     ]
-  },
+},
   "scripts": {
     "test": "jest --no-cache ./*",
     "watch": "jest --no-cache --watch ./*",
@@ -66,4 +67,3 @@
   ],
   "dependencies": {}
 }
-

--- a/exercises/kindergarten-garden/package.json
+++ b/exercises/kindergarten-garden/package.json
@@ -9,7 +9,7 @@
     "url": "https://github.com/exercism/xecmascript"
   },
   "devDependencies": {
-    "babel-jest": "^20.0.1",
+    "babel-jest": "^20.0.3",
     "babel-plugin-transform-builtin-extend": "^1.1.2",
     "babel-preset-env": "^1.4.0",
     "eslint": "^3.19.0",
@@ -17,7 +17,7 @@
     "eslint-plugin-import": "^2.2.0",
     "eslint-plugin-jsx-a11y": "^5.0.1",
     "eslint-plugin-react": "^7.0.1",
-    "jest": "^20.0.1"
+    "jest": "^20.0.4"
   },
   "jest": {
     "modulePathIgnorePatterns": [
@@ -36,9 +36,10 @@
             "Error"
           ]
         }
-      ]
+      ],
+      ["transform-regenerator"]
     ]
-  },
+},
   "scripts": {
     "test": "jest --no-cache ./*",
     "watch": "jest --no-cache --watch ./*",
@@ -66,4 +67,3 @@
   ],
   "dependencies": {}
 }
-

--- a/exercises/largest-series-product/package.json
+++ b/exercises/largest-series-product/package.json
@@ -9,7 +9,7 @@
     "url": "https://github.com/exercism/xecmascript"
   },
   "devDependencies": {
-    "babel-jest": "^20.0.1",
+    "babel-jest": "^20.0.3",
     "babel-plugin-transform-builtin-extend": "^1.1.2",
     "babel-preset-env": "^1.4.0",
     "eslint": "^3.19.0",
@@ -17,7 +17,7 @@
     "eslint-plugin-import": "^2.2.0",
     "eslint-plugin-jsx-a11y": "^5.0.1",
     "eslint-plugin-react": "^7.0.1",
-    "jest": "^20.0.1"
+    "jest": "^20.0.4"
   },
   "jest": {
     "modulePathIgnorePatterns": [
@@ -36,9 +36,10 @@
             "Error"
           ]
         }
-      ]
+      ],
+      ["transform-regenerator"]
     ]
-  },
+},
   "scripts": {
     "test": "jest --no-cache ./*",
     "watch": "jest --no-cache --watch ./*",
@@ -66,4 +67,3 @@
   ],
   "dependencies": {}
 }
-

--- a/exercises/leap/package.json
+++ b/exercises/leap/package.json
@@ -9,7 +9,7 @@
     "url": "https://github.com/exercism/xecmascript"
   },
   "devDependencies": {
-    "babel-jest": "^20.0.1",
+    "babel-jest": "^20.0.3",
     "babel-plugin-transform-builtin-extend": "^1.1.2",
     "babel-preset-env": "^1.4.0",
     "eslint": "^3.19.0",
@@ -17,7 +17,7 @@
     "eslint-plugin-import": "^2.2.0",
     "eslint-plugin-jsx-a11y": "^5.0.1",
     "eslint-plugin-react": "^7.0.1",
-    "jest": "^20.0.1"
+    "jest": "^20.0.4"
   },
   "jest": {
     "modulePathIgnorePatterns": [
@@ -36,9 +36,10 @@
             "Error"
           ]
         }
-      ]
+      ],
+      ["transform-regenerator"]
     ]
-  },
+},
   "scripts": {
     "test": "jest --no-cache ./*",
     "watch": "jest --no-cache --watch ./*",
@@ -66,4 +67,3 @@
   ],
   "dependencies": {}
 }
-

--- a/exercises/linked-list/package.json
+++ b/exercises/linked-list/package.json
@@ -9,7 +9,7 @@
     "url": "https://github.com/exercism/xecmascript"
   },
   "devDependencies": {
-    "babel-jest": "^20.0.1",
+    "babel-jest": "^20.0.3",
     "babel-plugin-transform-builtin-extend": "^1.1.2",
     "babel-preset-env": "^1.4.0",
     "eslint": "^3.19.0",
@@ -17,7 +17,7 @@
     "eslint-plugin-import": "^2.2.0",
     "eslint-plugin-jsx-a11y": "^5.0.1",
     "eslint-plugin-react": "^7.0.1",
-    "jest": "^20.0.1"
+    "jest": "^20.0.4"
   },
   "jest": {
     "modulePathIgnorePatterns": [
@@ -36,9 +36,10 @@
             "Error"
           ]
         }
-      ]
+      ],
+      ["transform-regenerator"]
     ]
-  },
+},
   "scripts": {
     "test": "jest --no-cache ./*",
     "watch": "jest --no-cache --watch ./*",
@@ -66,4 +67,3 @@
   ],
   "dependencies": {}
 }
-

--- a/exercises/list-ops/package.json
+++ b/exercises/list-ops/package.json
@@ -9,7 +9,7 @@
     "url": "https://github.com/exercism/xecmascript"
   },
   "devDependencies": {
-    "babel-jest": "^20.0.1",
+    "babel-jest": "^20.0.3",
     "babel-plugin-transform-builtin-extend": "^1.1.2",
     "babel-preset-env": "^1.4.0",
     "eslint": "^3.19.0",
@@ -17,7 +17,7 @@
     "eslint-plugin-import": "^2.2.0",
     "eslint-plugin-jsx-a11y": "^5.0.1",
     "eslint-plugin-react": "^7.0.1",
-    "jest": "^20.0.1"
+    "jest": "^20.0.4"
   },
   "jest": {
     "modulePathIgnorePatterns": [
@@ -36,9 +36,10 @@
             "Error"
           ]
         }
-      ]
+      ],
+      ["transform-regenerator"]
     ]
-  },
+},
   "scripts": {
     "test": "jest --no-cache ./*",
     "watch": "jest --no-cache --watch ./*",
@@ -66,4 +67,3 @@
   ],
   "dependencies": {}
 }
-

--- a/exercises/luhn/package.json
+++ b/exercises/luhn/package.json
@@ -9,7 +9,7 @@
     "url": "https://github.com/exercism/xecmascript"
   },
   "devDependencies": {
-    "babel-jest": "^20.0.1",
+    "babel-jest": "^20.0.3",
     "babel-plugin-transform-builtin-extend": "^1.1.2",
     "babel-preset-env": "^1.4.0",
     "eslint": "^3.19.0",
@@ -17,7 +17,7 @@
     "eslint-plugin-import": "^2.2.0",
     "eslint-plugin-jsx-a11y": "^5.0.1",
     "eslint-plugin-react": "^7.0.1",
-    "jest": "^20.0.1"
+    "jest": "^20.0.4"
   },
   "jest": {
     "modulePathIgnorePatterns": [
@@ -36,9 +36,10 @@
             "Error"
           ]
         }
-      ]
+      ],
+      ["transform-regenerator"]
     ]
-  },
+},
   "scripts": {
     "test": "jest --no-cache ./*",
     "watch": "jest --no-cache --watch ./*",
@@ -66,4 +67,3 @@
   ],
   "dependencies": {}
 }
-

--- a/exercises/matrix/package.json
+++ b/exercises/matrix/package.json
@@ -9,7 +9,7 @@
     "url": "https://github.com/exercism/xecmascript"
   },
   "devDependencies": {
-    "babel-jest": "^20.0.1",
+    "babel-jest": "^20.0.3",
     "babel-plugin-transform-builtin-extend": "^1.1.2",
     "babel-preset-env": "^1.4.0",
     "eslint": "^3.19.0",
@@ -17,7 +17,7 @@
     "eslint-plugin-import": "^2.2.0",
     "eslint-plugin-jsx-a11y": "^5.0.1",
     "eslint-plugin-react": "^7.0.1",
-    "jest": "^20.0.1"
+    "jest": "^20.0.4"
   },
   "jest": {
     "modulePathIgnorePatterns": [
@@ -36,9 +36,10 @@
             "Error"
           ]
         }
-      ]
+      ],
+      ["transform-regenerator"]
     ]
-  },
+},
   "scripts": {
     "test": "jest --no-cache ./*",
     "watch": "jest --no-cache --watch ./*",
@@ -66,4 +67,3 @@
   ],
   "dependencies": {}
 }
-

--- a/exercises/meetup/package.json
+++ b/exercises/meetup/package.json
@@ -9,7 +9,7 @@
     "url": "https://github.com/exercism/xecmascript"
   },
   "devDependencies": {
-    "babel-jest": "^20.0.1",
+    "babel-jest": "^20.0.3",
     "babel-plugin-transform-builtin-extend": "^1.1.2",
     "babel-preset-env": "^1.4.0",
     "eslint": "^3.19.0",
@@ -17,7 +17,7 @@
     "eslint-plugin-import": "^2.2.0",
     "eslint-plugin-jsx-a11y": "^5.0.1",
     "eslint-plugin-react": "^7.0.1",
-    "jest": "^20.0.1"
+    "jest": "^20.0.4"
   },
   "jest": {
     "modulePathIgnorePatterns": [
@@ -36,9 +36,10 @@
             "Error"
           ]
         }
-      ]
+      ],
+      ["transform-regenerator"]
     ]
-  },
+},
   "scripts": {
     "test": "jest --no-cache ./*",
     "watch": "jest --no-cache --watch ./*",
@@ -66,4 +67,3 @@
   ],
   "dependencies": {}
 }
-

--- a/exercises/minesweeper/package.json
+++ b/exercises/minesweeper/package.json
@@ -9,7 +9,7 @@
     "url": "https://github.com/exercism/xecmascript"
   },
   "devDependencies": {
-    "babel-jest": "^20.0.1",
+    "babel-jest": "^20.0.3",
     "babel-plugin-transform-builtin-extend": "^1.1.2",
     "babel-preset-env": "^1.4.0",
     "eslint": "^3.19.0",
@@ -17,7 +17,7 @@
     "eslint-plugin-import": "^2.2.0",
     "eslint-plugin-jsx-a11y": "^5.0.1",
     "eslint-plugin-react": "^7.0.1",
-    "jest": "^20.0.1"
+    "jest": "^20.0.4"
   },
   "jest": {
     "modulePathIgnorePatterns": [
@@ -36,9 +36,10 @@
             "Error"
           ]
         }
-      ]
+      ],
+      ["transform-regenerator"]
     ]
-  },
+},
   "scripts": {
     "test": "jest --no-cache ./*",
     "watch": "jest --no-cache --watch ./*",
@@ -66,4 +67,3 @@
   ],
   "dependencies": {}
 }
-

--- a/exercises/nth-prime/package.json
+++ b/exercises/nth-prime/package.json
@@ -9,7 +9,7 @@
     "url": "https://github.com/exercism/xecmascript"
   },
   "devDependencies": {
-    "babel-jest": "^20.0.1",
+    "babel-jest": "^20.0.3",
     "babel-plugin-transform-builtin-extend": "^1.1.2",
     "babel-preset-env": "^1.4.0",
     "eslint": "^3.19.0",
@@ -17,7 +17,7 @@
     "eslint-plugin-import": "^2.2.0",
     "eslint-plugin-jsx-a11y": "^5.0.1",
     "eslint-plugin-react": "^7.0.1",
-    "jest": "^20.0.1"
+    "jest": "^20.0.4"
   },
   "jest": {
     "modulePathIgnorePatterns": [
@@ -36,9 +36,10 @@
             "Error"
           ]
         }
-      ]
+      ],
+      ["transform-regenerator"]
     ]
-  },
+},
   "scripts": {
     "test": "jest --no-cache ./*",
     "watch": "jest --no-cache --watch ./*",
@@ -66,4 +67,3 @@
   ],
   "dependencies": {}
 }
-

--- a/exercises/ocr-numbers/package.json
+++ b/exercises/ocr-numbers/package.json
@@ -9,7 +9,7 @@
     "url": "https://github.com/exercism/xecmascript"
   },
   "devDependencies": {
-    "babel-jest": "^20.0.1",
+    "babel-jest": "^20.0.3",
     "babel-plugin-transform-builtin-extend": "^1.1.2",
     "babel-preset-env": "^1.4.0",
     "eslint": "^3.19.0",
@@ -17,7 +17,7 @@
     "eslint-plugin-import": "^2.2.0",
     "eslint-plugin-jsx-a11y": "^5.0.1",
     "eslint-plugin-react": "^7.0.1",
-    "jest": "^20.0.1"
+    "jest": "^20.0.4"
   },
   "jest": {
     "modulePathIgnorePatterns": [
@@ -36,9 +36,10 @@
             "Error"
           ]
         }
-      ]
+      ],
+      ["transform-regenerator"]
     ]
-  },
+},
   "scripts": {
     "test": "jest --no-cache ./*",
     "watch": "jest --no-cache --watch ./*",
@@ -66,4 +67,3 @@
   ],
   "dependencies": {}
 }
-

--- a/exercises/octal/package.json
+++ b/exercises/octal/package.json
@@ -9,7 +9,7 @@
     "url": "https://github.com/exercism/xecmascript"
   },
   "devDependencies": {
-    "babel-jest": "^20.0.1",
+    "babel-jest": "^20.0.3",
     "babel-plugin-transform-builtin-extend": "^1.1.2",
     "babel-preset-env": "^1.4.0",
     "eslint": "^3.19.0",
@@ -17,7 +17,7 @@
     "eslint-plugin-import": "^2.2.0",
     "eslint-plugin-jsx-a11y": "^5.0.1",
     "eslint-plugin-react": "^7.0.1",
-    "jest": "^20.0.1"
+    "jest": "^20.0.4"
   },
   "jest": {
     "modulePathIgnorePatterns": [
@@ -36,9 +36,10 @@
             "Error"
           ]
         }
-      ]
+      ],
+      ["transform-regenerator"]
     ]
-  },
+},
   "scripts": {
     "test": "jest --no-cache ./*",
     "watch": "jest --no-cache --watch ./*",
@@ -66,4 +67,3 @@
   ],
   "dependencies": {}
 }
-

--- a/exercises/palindrome-products/package.json
+++ b/exercises/palindrome-products/package.json
@@ -9,7 +9,7 @@
     "url": "https://github.com/exercism/xecmascript"
   },
   "devDependencies": {
-    "babel-jest": "^20.0.1",
+    "babel-jest": "^20.0.3",
     "babel-plugin-transform-builtin-extend": "^1.1.2",
     "babel-preset-env": "^1.4.0",
     "eslint": "^3.19.0",
@@ -17,7 +17,7 @@
     "eslint-plugin-import": "^2.2.0",
     "eslint-plugin-jsx-a11y": "^5.0.1",
     "eslint-plugin-react": "^7.0.1",
-    "jest": "^20.0.1"
+    "jest": "^20.0.4"
   },
   "jest": {
     "modulePathIgnorePatterns": [
@@ -36,9 +36,10 @@
             "Error"
           ]
         }
-      ]
+      ],
+      ["transform-regenerator"]
     ]
-  },
+},
   "scripts": {
     "test": "jest --no-cache ./*",
     "watch": "jest --no-cache --watch ./*",
@@ -66,4 +67,3 @@
   ],
   "dependencies": {}
 }
-

--- a/exercises/pangram/package.json
+++ b/exercises/pangram/package.json
@@ -9,7 +9,7 @@
     "url": "https://github.com/exercism/xecmascript"
   },
   "devDependencies": {
-    "babel-jest": "^20.0.1",
+    "babel-jest": "^20.0.3",
     "babel-plugin-transform-builtin-extend": "^1.1.2",
     "babel-preset-env": "^1.4.0",
     "eslint": "^3.19.0",
@@ -17,7 +17,7 @@
     "eslint-plugin-import": "^2.2.0",
     "eslint-plugin-jsx-a11y": "^5.0.1",
     "eslint-plugin-react": "^7.0.1",
-    "jest": "^20.0.1"
+    "jest": "^20.0.4"
   },
   "jest": {
     "modulePathIgnorePatterns": [
@@ -36,9 +36,10 @@
             "Error"
           ]
         }
-      ]
+      ],
+      ["transform-regenerator"]
     ]
-  },
+},
   "scripts": {
     "test": "jest --no-cache ./*",
     "watch": "jest --no-cache --watch ./*",
@@ -66,4 +67,3 @@
   ],
   "dependencies": {}
 }
-

--- a/exercises/pascals-triangle/package.json
+++ b/exercises/pascals-triangle/package.json
@@ -9,7 +9,7 @@
     "url": "https://github.com/exercism/xecmascript"
   },
   "devDependencies": {
-    "babel-jest": "^20.0.1",
+    "babel-jest": "^20.0.3",
     "babel-plugin-transform-builtin-extend": "^1.1.2",
     "babel-preset-env": "^1.4.0",
     "eslint": "^3.19.0",
@@ -17,7 +17,7 @@
     "eslint-plugin-import": "^2.2.0",
     "eslint-plugin-jsx-a11y": "^5.0.1",
     "eslint-plugin-react": "^7.0.1",
-    "jest": "^20.0.1"
+    "jest": "^20.0.4"
   },
   "jest": {
     "modulePathIgnorePatterns": [
@@ -36,9 +36,10 @@
             "Error"
           ]
         }
-      ]
+      ],
+      ["transform-regenerator"]
     ]
-  },
+},
   "scripts": {
     "test": "jest --no-cache ./*",
     "watch": "jest --no-cache --watch ./*",
@@ -66,4 +67,3 @@
   ],
   "dependencies": {}
 }
-

--- a/exercises/perfect-numbers/package.json
+++ b/exercises/perfect-numbers/package.json
@@ -9,7 +9,7 @@
     "url": "https://github.com/exercism/xecmascript"
   },
   "devDependencies": {
-    "babel-jest": "^20.0.1",
+    "babel-jest": "^20.0.3",
     "babel-plugin-transform-builtin-extend": "^1.1.2",
     "babel-preset-env": "^1.4.0",
     "eslint": "^3.19.0",
@@ -17,7 +17,7 @@
     "eslint-plugin-import": "^2.2.0",
     "eslint-plugin-jsx-a11y": "^5.0.1",
     "eslint-plugin-react": "^7.0.1",
-    "jest": "^20.0.1"
+    "jest": "^20.0.4"
   },
   "jest": {
     "modulePathIgnorePatterns": [
@@ -36,9 +36,10 @@
             "Error"
           ]
         }
-      ]
+      ],
+      ["transform-regenerator"]
     ]
-  },
+},
   "scripts": {
     "test": "jest --no-cache ./*",
     "watch": "jest --no-cache --watch ./*",
@@ -66,4 +67,3 @@
   ],
   "dependencies": {}
 }
-

--- a/exercises/phone-number/package.json
+++ b/exercises/phone-number/package.json
@@ -9,7 +9,7 @@
     "url": "https://github.com/exercism/xecmascript"
   },
   "devDependencies": {
-    "babel-jest": "^20.0.1",
+    "babel-jest": "^20.0.3",
     "babel-plugin-transform-builtin-extend": "^1.1.2",
     "babel-preset-env": "^1.4.0",
     "eslint": "^3.19.0",
@@ -17,7 +17,7 @@
     "eslint-plugin-import": "^2.2.0",
     "eslint-plugin-jsx-a11y": "^5.0.1",
     "eslint-plugin-react": "^7.0.1",
-    "jest": "^20.0.1"
+    "jest": "^20.0.4"
   },
   "jest": {
     "modulePathIgnorePatterns": [
@@ -36,9 +36,10 @@
             "Error"
           ]
         }
-      ]
+      ],
+      ["transform-regenerator"]
     ]
-  },
+},
   "scripts": {
     "test": "jest --no-cache ./*",
     "watch": "jest --no-cache --watch ./*",
@@ -66,4 +67,3 @@
   ],
   "dependencies": {}
 }
-

--- a/exercises/pig-latin/package.json
+++ b/exercises/pig-latin/package.json
@@ -9,7 +9,7 @@
     "url": "https://github.com/exercism/xecmascript"
   },
   "devDependencies": {
-    "babel-jest": "^20.0.1",
+    "babel-jest": "^20.0.3",
     "babel-plugin-transform-builtin-extend": "^1.1.2",
     "babel-preset-env": "^1.4.0",
     "eslint": "^3.19.0",
@@ -17,7 +17,7 @@
     "eslint-plugin-import": "^2.2.0",
     "eslint-plugin-jsx-a11y": "^5.0.1",
     "eslint-plugin-react": "^7.0.1",
-    "jest": "^20.0.1"
+    "jest": "^20.0.4"
   },
   "jest": {
     "modulePathIgnorePatterns": [
@@ -36,9 +36,10 @@
             "Error"
           ]
         }
-      ]
+      ],
+      ["transform-regenerator"]
     ]
-  },
+},
   "scripts": {
     "test": "jest --no-cache ./*",
     "watch": "jest --no-cache --watch ./*",
@@ -66,4 +67,3 @@
   ],
   "dependencies": {}
 }
-

--- a/exercises/prime-factors/package.json
+++ b/exercises/prime-factors/package.json
@@ -9,7 +9,7 @@
     "url": "https://github.com/exercism/xecmascript"
   },
   "devDependencies": {
-    "babel-jest": "^20.0.1",
+    "babel-jest": "^20.0.3",
     "babel-plugin-transform-builtin-extend": "^1.1.2",
     "babel-preset-env": "^1.4.0",
     "eslint": "^3.19.0",
@@ -17,7 +17,7 @@
     "eslint-plugin-import": "^2.2.0",
     "eslint-plugin-jsx-a11y": "^5.0.1",
     "eslint-plugin-react": "^7.0.1",
-    "jest": "^20.0.1"
+    "jest": "^20.0.4"
   },
   "jest": {
     "modulePathIgnorePatterns": [
@@ -36,9 +36,10 @@
             "Error"
           ]
         }
-      ]
+      ],
+      ["transform-regenerator"]
     ]
-  },
+},
   "scripts": {
     "test": "jest --no-cache ./*",
     "watch": "jest --no-cache --watch ./*",
@@ -66,4 +67,3 @@
   ],
   "dependencies": {}
 }
-

--- a/exercises/pythagorean-triplet/package.json
+++ b/exercises/pythagorean-triplet/package.json
@@ -9,7 +9,7 @@
     "url": "https://github.com/exercism/xecmascript"
   },
   "devDependencies": {
-    "babel-jest": "^20.0.1",
+    "babel-jest": "^20.0.3",
     "babel-plugin-transform-builtin-extend": "^1.1.2",
     "babel-preset-env": "^1.4.0",
     "eslint": "^3.19.0",
@@ -17,7 +17,7 @@
     "eslint-plugin-import": "^2.2.0",
     "eslint-plugin-jsx-a11y": "^5.0.1",
     "eslint-plugin-react": "^7.0.1",
-    "jest": "^20.0.1"
+    "jest": "^20.0.4"
   },
   "jest": {
     "modulePathIgnorePatterns": [
@@ -36,9 +36,10 @@
             "Error"
           ]
         }
-      ]
+      ],
+      ["transform-regenerator"]
     ]
-  },
+},
   "scripts": {
     "test": "jest --no-cache ./*",
     "watch": "jest --no-cache --watch ./*",
@@ -66,4 +67,3 @@
   ],
   "dependencies": {}
 }
-

--- a/exercises/queen-attack/package.json
+++ b/exercises/queen-attack/package.json
@@ -9,7 +9,7 @@
     "url": "https://github.com/exercism/xecmascript"
   },
   "devDependencies": {
-    "babel-jest": "^20.0.1",
+    "babel-jest": "^20.0.3",
     "babel-plugin-transform-builtin-extend": "^1.1.2",
     "babel-preset-env": "^1.4.0",
     "eslint": "^3.19.0",
@@ -17,7 +17,7 @@
     "eslint-plugin-import": "^2.2.0",
     "eslint-plugin-jsx-a11y": "^5.0.1",
     "eslint-plugin-react": "^7.0.1",
-    "jest": "^20.0.1"
+    "jest": "^20.0.4"
   },
   "jest": {
     "modulePathIgnorePatterns": [
@@ -36,9 +36,10 @@
             "Error"
           ]
         }
-      ]
+      ],
+      ["transform-regenerator"]
     ]
-  },
+},
   "scripts": {
     "test": "jest --no-cache ./*",
     "watch": "jest --no-cache --watch ./*",
@@ -66,4 +67,3 @@
   ],
   "dependencies": {}
 }
-

--- a/exercises/raindrops/package.json
+++ b/exercises/raindrops/package.json
@@ -9,7 +9,7 @@
     "url": "https://github.com/exercism/xecmascript"
   },
   "devDependencies": {
-    "babel-jest": "^20.0.1",
+    "babel-jest": "^20.0.3",
     "babel-plugin-transform-builtin-extend": "^1.1.2",
     "babel-preset-env": "^1.4.0",
     "eslint": "^3.19.0",
@@ -17,7 +17,7 @@
     "eslint-plugin-import": "^2.2.0",
     "eslint-plugin-jsx-a11y": "^5.0.1",
     "eslint-plugin-react": "^7.0.1",
-    "jest": "^20.0.1"
+    "jest": "^20.0.4"
   },
   "jest": {
     "modulePathIgnorePatterns": [
@@ -36,9 +36,10 @@
             "Error"
           ]
         }
-      ]
+      ],
+      ["transform-regenerator"]
     ]
-  },
+},
   "scripts": {
     "test": "jest --no-cache ./*",
     "watch": "jest --no-cache --watch ./*",
@@ -66,4 +67,3 @@
   ],
   "dependencies": {}
 }
-

--- a/exercises/rna-transcription/package.json
+++ b/exercises/rna-transcription/package.json
@@ -9,7 +9,7 @@
     "url": "https://github.com/exercism/xecmascript"
   },
   "devDependencies": {
-    "babel-jest": "^20.0.1",
+    "babel-jest": "^20.0.3",
     "babel-plugin-transform-builtin-extend": "^1.1.2",
     "babel-preset-env": "^1.4.0",
     "eslint": "^3.19.0",
@@ -17,7 +17,7 @@
     "eslint-plugin-import": "^2.2.0",
     "eslint-plugin-jsx-a11y": "^5.0.1",
     "eslint-plugin-react": "^7.0.1",
-    "jest": "^20.0.1"
+    "jest": "^20.0.4"
   },
   "jest": {
     "modulePathIgnorePatterns": [
@@ -36,9 +36,10 @@
             "Error"
           ]
         }
-      ]
+      ],
+      ["transform-regenerator"]
     ]
-  },
+},
   "scripts": {
     "test": "jest --no-cache ./*",
     "watch": "jest --no-cache --watch ./*",
@@ -66,4 +67,3 @@
   ],
   "dependencies": {}
 }
-

--- a/exercises/robot-name/package.json
+++ b/exercises/robot-name/package.json
@@ -9,7 +9,7 @@
     "url": "https://github.com/exercism/xecmascript"
   },
   "devDependencies": {
-    "babel-jest": "^20.0.1",
+    "babel-jest": "^20.0.3",
     "babel-plugin-transform-builtin-extend": "^1.1.2",
     "babel-preset-env": "^1.4.0",
     "eslint": "^3.19.0",
@@ -17,7 +17,7 @@
     "eslint-plugin-import": "^2.2.0",
     "eslint-plugin-jsx-a11y": "^5.0.1",
     "eslint-plugin-react": "^7.0.1",
-    "jest": "^20.0.1"
+    "jest": "^20.0.4"
   },
   "jest": {
     "modulePathIgnorePatterns": [
@@ -36,9 +36,10 @@
             "Error"
           ]
         }
-      ]
+      ],
+      ["transform-regenerator"]
     ]
-  },
+},
   "scripts": {
     "test": "jest --no-cache ./*",
     "watch": "jest --no-cache --watch ./*",
@@ -66,4 +67,3 @@
   ],
   "dependencies": {}
 }
-

--- a/exercises/robot-simulator/package.json
+++ b/exercises/robot-simulator/package.json
@@ -9,7 +9,7 @@
     "url": "https://github.com/exercism/xecmascript"
   },
   "devDependencies": {
-    "babel-jest": "^20.0.1",
+    "babel-jest": "^20.0.3",
     "babel-plugin-transform-builtin-extend": "^1.1.2",
     "babel-preset-env": "^1.4.0",
     "eslint": "^3.19.0",
@@ -17,7 +17,7 @@
     "eslint-plugin-import": "^2.2.0",
     "eslint-plugin-jsx-a11y": "^5.0.1",
     "eslint-plugin-react": "^7.0.1",
-    "jest": "^20.0.1"
+    "jest": "^20.0.4"
   },
   "jest": {
     "modulePathIgnorePatterns": [
@@ -36,9 +36,10 @@
             "Error"
           ]
         }
-      ]
+      ],
+      ["transform-regenerator"]
     ]
-  },
+},
   "scripts": {
     "test": "jest --no-cache ./*",
     "watch": "jest --no-cache --watch ./*",
@@ -66,4 +67,3 @@
   ],
   "dependencies": {}
 }
-

--- a/exercises/roman-numerals/package.json
+++ b/exercises/roman-numerals/package.json
@@ -9,7 +9,7 @@
     "url": "https://github.com/exercism/xecmascript"
   },
   "devDependencies": {
-    "babel-jest": "^20.0.1",
+    "babel-jest": "^20.0.3",
     "babel-plugin-transform-builtin-extend": "^1.1.2",
     "babel-preset-env": "^1.4.0",
     "eslint": "^3.19.0",
@@ -17,7 +17,7 @@
     "eslint-plugin-import": "^2.2.0",
     "eslint-plugin-jsx-a11y": "^5.0.1",
     "eslint-plugin-react": "^7.0.1",
-    "jest": "^20.0.1"
+    "jest": "^20.0.4"
   },
   "jest": {
     "modulePathIgnorePatterns": [
@@ -36,9 +36,10 @@
             "Error"
           ]
         }
-      ]
+      ],
+      ["transform-regenerator"]
     ]
-  },
+},
   "scripts": {
     "test": "jest --no-cache ./*",
     "watch": "jest --no-cache --watch ./*",
@@ -66,4 +67,3 @@
   ],
   "dependencies": {}
 }
-

--- a/exercises/saddle-points/package.json
+++ b/exercises/saddle-points/package.json
@@ -9,7 +9,7 @@
     "url": "https://github.com/exercism/xecmascript"
   },
   "devDependencies": {
-    "babel-jest": "^20.0.1",
+    "babel-jest": "^20.0.3",
     "babel-plugin-transform-builtin-extend": "^1.1.2",
     "babel-preset-env": "^1.4.0",
     "eslint": "^3.19.0",
@@ -17,7 +17,7 @@
     "eslint-plugin-import": "^2.2.0",
     "eslint-plugin-jsx-a11y": "^5.0.1",
     "eslint-plugin-react": "^7.0.1",
-    "jest": "^20.0.1"
+    "jest": "^20.0.4"
   },
   "jest": {
     "modulePathIgnorePatterns": [
@@ -36,9 +36,10 @@
             "Error"
           ]
         }
-      ]
+      ],
+      ["transform-regenerator"]
     ]
-  },
+},
   "scripts": {
     "test": "jest --no-cache ./*",
     "watch": "jest --no-cache --watch ./*",
@@ -66,4 +67,3 @@
   ],
   "dependencies": {}
 }
-

--- a/exercises/say/package.json
+++ b/exercises/say/package.json
@@ -9,7 +9,7 @@
     "url": "https://github.com/exercism/xecmascript"
   },
   "devDependencies": {
-    "babel-jest": "^20.0.1",
+    "babel-jest": "^20.0.3",
     "babel-plugin-transform-builtin-extend": "^1.1.2",
     "babel-preset-env": "^1.4.0",
     "eslint": "^3.19.0",
@@ -17,7 +17,7 @@
     "eslint-plugin-import": "^2.2.0",
     "eslint-plugin-jsx-a11y": "^5.0.1",
     "eslint-plugin-react": "^7.0.1",
-    "jest": "^20.0.1"
+    "jest": "^20.0.4"
   },
   "jest": {
     "modulePathIgnorePatterns": [
@@ -36,9 +36,10 @@
             "Error"
           ]
         }
-      ]
+      ],
+      ["transform-regenerator"]
     ]
-  },
+},
   "scripts": {
     "test": "jest --no-cache ./*",
     "watch": "jest --no-cache --watch ./*",
@@ -66,4 +67,3 @@
   ],
   "dependencies": {}
 }
-

--- a/exercises/scrabble-score/package.json
+++ b/exercises/scrabble-score/package.json
@@ -9,7 +9,7 @@
     "url": "https://github.com/exercism/xecmascript"
   },
   "devDependencies": {
-    "babel-jest": "^20.0.1",
+    "babel-jest": "^20.0.3",
     "babel-plugin-transform-builtin-extend": "^1.1.2",
     "babel-preset-env": "^1.4.0",
     "eslint": "^3.19.0",
@@ -17,7 +17,7 @@
     "eslint-plugin-import": "^2.2.0",
     "eslint-plugin-jsx-a11y": "^5.0.1",
     "eslint-plugin-react": "^7.0.1",
-    "jest": "^20.0.1"
+    "jest": "^20.0.4"
   },
   "jest": {
     "modulePathIgnorePatterns": [
@@ -36,9 +36,10 @@
             "Error"
           ]
         }
-      ]
+      ],
+      ["transform-regenerator"]
     ]
-  },
+},
   "scripts": {
     "test": "jest --no-cache ./*",
     "watch": "jest --no-cache --watch ./*",
@@ -66,4 +67,3 @@
   ],
   "dependencies": {}
 }
-

--- a/exercises/secret-handshake/package.json
+++ b/exercises/secret-handshake/package.json
@@ -9,7 +9,7 @@
     "url": "https://github.com/exercism/xecmascript"
   },
   "devDependencies": {
-    "babel-jest": "^20.0.1",
+    "babel-jest": "^20.0.3",
     "babel-plugin-transform-builtin-extend": "^1.1.2",
     "babel-preset-env": "^1.4.0",
     "eslint": "^3.19.0",
@@ -17,7 +17,7 @@
     "eslint-plugin-import": "^2.2.0",
     "eslint-plugin-jsx-a11y": "^5.0.1",
     "eslint-plugin-react": "^7.0.1",
-    "jest": "^20.0.1"
+    "jest": "^20.0.4"
   },
   "jest": {
     "modulePathIgnorePatterns": [
@@ -36,9 +36,10 @@
             "Error"
           ]
         }
-      ]
+      ],
+      ["transform-regenerator"]
     ]
-  },
+},
   "scripts": {
     "test": "jest --no-cache ./*",
     "watch": "jest --no-cache --watch ./*",
@@ -66,4 +67,3 @@
   ],
   "dependencies": {}
 }
-

--- a/exercises/series/package.json
+++ b/exercises/series/package.json
@@ -9,7 +9,7 @@
     "url": "https://github.com/exercism/xecmascript"
   },
   "devDependencies": {
-    "babel-jest": "^20.0.1",
+    "babel-jest": "^20.0.3",
     "babel-plugin-transform-builtin-extend": "^1.1.2",
     "babel-preset-env": "^1.4.0",
     "eslint": "^3.19.0",
@@ -17,7 +17,7 @@
     "eslint-plugin-import": "^2.2.0",
     "eslint-plugin-jsx-a11y": "^5.0.1",
     "eslint-plugin-react": "^7.0.1",
-    "jest": "^20.0.1"
+    "jest": "^20.0.4"
   },
   "jest": {
     "modulePathIgnorePatterns": [
@@ -36,9 +36,10 @@
             "Error"
           ]
         }
-      ]
+      ],
+      ["transform-regenerator"]
     ]
-  },
+},
   "scripts": {
     "test": "jest --no-cache ./*",
     "watch": "jest --no-cache --watch ./*",
@@ -66,4 +67,3 @@
   ],
   "dependencies": {}
 }
-

--- a/exercises/sieve/package.json
+++ b/exercises/sieve/package.json
@@ -9,7 +9,7 @@
     "url": "https://github.com/exercism/xecmascript"
   },
   "devDependencies": {
-    "babel-jest": "^20.0.1",
+    "babel-jest": "^20.0.3",
     "babel-plugin-transform-builtin-extend": "^1.1.2",
     "babel-preset-env": "^1.4.0",
     "eslint": "^3.19.0",
@@ -17,7 +17,7 @@
     "eslint-plugin-import": "^2.2.0",
     "eslint-plugin-jsx-a11y": "^5.0.1",
     "eslint-plugin-react": "^7.0.1",
-    "jest": "^20.0.1"
+    "jest": "^20.0.4"
   },
   "jest": {
     "modulePathIgnorePatterns": [
@@ -36,9 +36,10 @@
             "Error"
           ]
         }
-      ]
+      ],
+      ["transform-regenerator"]
     ]
-  },
+},
   "scripts": {
     "test": "jest --no-cache ./*",
     "watch": "jest --no-cache --watch ./*",
@@ -66,4 +67,3 @@
   ],
   "dependencies": {}
 }
-

--- a/exercises/simple-cipher/package.json
+++ b/exercises/simple-cipher/package.json
@@ -9,7 +9,7 @@
     "url": "https://github.com/exercism/xecmascript"
   },
   "devDependencies": {
-    "babel-jest": "^20.0.1",
+    "babel-jest": "^20.0.3",
     "babel-plugin-transform-builtin-extend": "^1.1.2",
     "babel-preset-env": "^1.4.0",
     "eslint": "^3.19.0",
@@ -17,7 +17,7 @@
     "eslint-plugin-import": "^2.2.0",
     "eslint-plugin-jsx-a11y": "^5.0.1",
     "eslint-plugin-react": "^7.0.1",
-    "jest": "^20.0.1"
+    "jest": "^20.0.4"
   },
   "jest": {
     "modulePathIgnorePatterns": [
@@ -36,9 +36,10 @@
             "Error"
           ]
         }
-      ]
+      ],
+      ["transform-regenerator"]
     ]
-  },
+},
   "scripts": {
     "test": "jest --no-cache ./*",
     "watch": "jest --no-cache --watch ./*",
@@ -66,4 +67,3 @@
   ],
   "dependencies": {}
 }
-

--- a/exercises/space-age/package.json
+++ b/exercises/space-age/package.json
@@ -9,7 +9,7 @@
     "url": "https://github.com/exercism/xecmascript"
   },
   "devDependencies": {
-    "babel-jest": "^20.0.1",
+    "babel-jest": "^20.0.3",
     "babel-plugin-transform-builtin-extend": "^1.1.2",
     "babel-preset-env": "^1.4.0",
     "eslint": "^3.19.0",
@@ -17,7 +17,7 @@
     "eslint-plugin-import": "^2.2.0",
     "eslint-plugin-jsx-a11y": "^5.0.1",
     "eslint-plugin-react": "^7.0.1",
-    "jest": "^20.0.1"
+    "jest": "^20.0.4"
   },
   "jest": {
     "modulePathIgnorePatterns": [
@@ -36,9 +36,10 @@
             "Error"
           ]
         }
-      ]
+      ],
+      ["transform-regenerator"]
     ]
-  },
+},
   "scripts": {
     "test": "jest --no-cache ./*",
     "watch": "jest --no-cache --watch ./*",
@@ -66,4 +67,3 @@
   ],
   "dependencies": {}
 }
-

--- a/exercises/strain/package.json
+++ b/exercises/strain/package.json
@@ -9,7 +9,7 @@
     "url": "https://github.com/exercism/xecmascript"
   },
   "devDependencies": {
-    "babel-jest": "^20.0.1",
+    "babel-jest": "^20.0.3",
     "babel-plugin-transform-builtin-extend": "^1.1.2",
     "babel-preset-env": "^1.4.0",
     "eslint": "^3.19.0",
@@ -17,7 +17,7 @@
     "eslint-plugin-import": "^2.2.0",
     "eslint-plugin-jsx-a11y": "^5.0.1",
     "eslint-plugin-react": "^7.0.1",
-    "jest": "^20.0.1"
+    "jest": "^20.0.4"
   },
   "jest": {
     "modulePathIgnorePatterns": [
@@ -36,9 +36,10 @@
             "Error"
           ]
         }
-      ]
+      ],
+      ["transform-regenerator"]
     ]
-  },
+},
   "scripts": {
     "test": "jest --no-cache ./*",
     "watch": "jest --no-cache --watch ./*",
@@ -66,4 +67,3 @@
   ],
   "dependencies": {}
 }
-

--- a/exercises/sublist/package.json
+++ b/exercises/sublist/package.json
@@ -9,7 +9,7 @@
     "url": "https://github.com/exercism/xecmascript"
   },
   "devDependencies": {
-    "babel-jest": "^20.0.1",
+    "babel-jest": "^20.0.3",
     "babel-plugin-transform-builtin-extend": "^1.1.2",
     "babel-preset-env": "^1.4.0",
     "eslint": "^3.19.0",
@@ -17,7 +17,7 @@
     "eslint-plugin-import": "^2.2.0",
     "eslint-plugin-jsx-a11y": "^5.0.1",
     "eslint-plugin-react": "^7.0.1",
-    "jest": "^20.0.1"
+    "jest": "^20.0.4"
   },
   "jest": {
     "modulePathIgnorePatterns": [
@@ -36,9 +36,10 @@
             "Error"
           ]
         }
-      ]
+      ],
+      ["transform-regenerator"]
     ]
-  },
+},
   "scripts": {
     "test": "jest --no-cache ./*",
     "watch": "jest --no-cache --watch ./*",
@@ -66,4 +67,3 @@
   ],
   "dependencies": {}
 }
-

--- a/exercises/sum-of-multiples/package.json
+++ b/exercises/sum-of-multiples/package.json
@@ -9,7 +9,7 @@
     "url": "https://github.com/exercism/xecmascript"
   },
   "devDependencies": {
-    "babel-jest": "^20.0.1",
+    "babel-jest": "^20.0.3",
     "babel-plugin-transform-builtin-extend": "^1.1.2",
     "babel-preset-env": "^1.4.0",
     "eslint": "^3.19.0",
@@ -17,7 +17,7 @@
     "eslint-plugin-import": "^2.2.0",
     "eslint-plugin-jsx-a11y": "^5.0.1",
     "eslint-plugin-react": "^7.0.1",
-    "jest": "^20.0.1"
+    "jest": "^20.0.4"
   },
   "jest": {
     "modulePathIgnorePatterns": [
@@ -36,9 +36,10 @@
             "Error"
           ]
         }
-      ]
+      ],
+      ["transform-regenerator"]
     ]
-  },
+},
   "scripts": {
     "test": "jest --no-cache ./*",
     "watch": "jest --no-cache --watch ./*",
@@ -66,4 +67,3 @@
   ],
   "dependencies": {}
 }
-

--- a/exercises/triangle/package.json
+++ b/exercises/triangle/package.json
@@ -9,7 +9,7 @@
     "url": "https://github.com/exercism/xecmascript"
   },
   "devDependencies": {
-    "babel-jest": "^20.0.1",
+    "babel-jest": "^20.0.3",
     "babel-plugin-transform-builtin-extend": "^1.1.2",
     "babel-preset-env": "^1.4.0",
     "eslint": "^3.19.0",
@@ -17,7 +17,7 @@
     "eslint-plugin-import": "^2.2.0",
     "eslint-plugin-jsx-a11y": "^5.0.1",
     "eslint-plugin-react": "^7.0.1",
-    "jest": "^20.0.1"
+    "jest": "^20.0.4"
   },
   "jest": {
     "modulePathIgnorePatterns": [
@@ -36,9 +36,10 @@
             "Error"
           ]
         }
-      ]
+      ],
+      ["transform-regenerator"]
     ]
-  },
+},
   "scripts": {
     "test": "jest --no-cache ./*",
     "watch": "jest --no-cache --watch ./*",
@@ -66,4 +67,3 @@
   ],
   "dependencies": {}
 }
-

--- a/exercises/trinary/package.json
+++ b/exercises/trinary/package.json
@@ -9,7 +9,7 @@
     "url": "https://github.com/exercism/xecmascript"
   },
   "devDependencies": {
-    "babel-jest": "^20.0.1",
+    "babel-jest": "^20.0.3",
     "babel-plugin-transform-builtin-extend": "^1.1.2",
     "babel-preset-env": "^1.4.0",
     "eslint": "^3.19.0",
@@ -17,7 +17,7 @@
     "eslint-plugin-import": "^2.2.0",
     "eslint-plugin-jsx-a11y": "^5.0.1",
     "eslint-plugin-react": "^7.0.1",
-    "jest": "^20.0.1"
+    "jest": "^20.0.4"
   },
   "jest": {
     "modulePathIgnorePatterns": [
@@ -36,9 +36,10 @@
             "Error"
           ]
         }
-      ]
+      ],
+      ["transform-regenerator"]
     ]
-  },
+},
   "scripts": {
     "test": "jest --no-cache ./*",
     "watch": "jest --no-cache --watch ./*",
@@ -66,4 +67,3 @@
   ],
   "dependencies": {}
 }
-

--- a/exercises/twelve-days/package.json
+++ b/exercises/twelve-days/package.json
@@ -9,7 +9,7 @@
     "url": "https://github.com/exercism/xecmascript"
   },
   "devDependencies": {
-    "babel-jest": "^20.0.1",
+    "babel-jest": "^20.0.3",
     "babel-plugin-transform-builtin-extend": "^1.1.2",
     "babel-preset-env": "^1.4.0",
     "eslint": "^3.19.0",
@@ -17,7 +17,7 @@
     "eslint-plugin-import": "^2.2.0",
     "eslint-plugin-jsx-a11y": "^5.0.1",
     "eslint-plugin-react": "^7.0.1",
-    "jest": "^20.0.1"
+    "jest": "^20.0.4"
   },
   "jest": {
     "modulePathIgnorePatterns": [
@@ -36,9 +36,10 @@
             "Error"
           ]
         }
-      ]
+      ],
+      ["transform-regenerator"]
     ]
-  },
+},
   "scripts": {
     "test": "jest --no-cache ./*",
     "watch": "jest --no-cache --watch ./*",

--- a/exercises/two-bucket/package.json
+++ b/exercises/two-bucket/package.json
@@ -9,7 +9,7 @@
     "url": "https://github.com/exercism/xecmascript"
   },
   "devDependencies": {
-    "babel-jest": "^20.0.1",
+    "babel-jest": "^20.0.3",
     "babel-plugin-transform-builtin-extend": "^1.1.2",
     "babel-preset-env": "^1.4.0",
     "eslint": "^3.19.0",
@@ -17,7 +17,7 @@
     "eslint-plugin-import": "^2.2.0",
     "eslint-plugin-jsx-a11y": "^5.0.1",
     "eslint-plugin-react": "^7.0.1",
-    "jest": "^20.0.1"
+    "jest": "^20.0.4"
   },
   "jest": {
     "modulePathIgnorePatterns": [
@@ -36,9 +36,10 @@
             "Error"
           ]
         }
-      ]
+      ],
+      ["transform-regenerator"]
     ]
-  },
+},
   "scripts": {
     "test": "jest --no-cache ./*",
     "watch": "jest --no-cache --watch ./*",
@@ -66,4 +67,3 @@
   ],
   "dependencies": {}
 }
-

--- a/exercises/word-count/package.json
+++ b/exercises/word-count/package.json
@@ -9,7 +9,7 @@
     "url": "https://github.com/exercism/xecmascript"
   },
   "devDependencies": {
-    "babel-jest": "^20.0.1",
+    "babel-jest": "^20.0.3",
     "babel-plugin-transform-builtin-extend": "^1.1.2",
     "babel-preset-env": "^1.4.0",
     "eslint": "^3.19.0",
@@ -17,7 +17,7 @@
     "eslint-plugin-import": "^2.2.0",
     "eslint-plugin-jsx-a11y": "^5.0.1",
     "eslint-plugin-react": "^7.0.1",
-    "jest": "^20.0.1"
+    "jest": "^20.0.4"
   },
   "jest": {
     "modulePathIgnorePatterns": [
@@ -36,9 +36,10 @@
             "Error"
           ]
         }
-      ]
+      ],
+      ["transform-regenerator"]
     ]
-  },
+},
   "scripts": {
     "test": "jest --no-cache ./*",
     "watch": "jest --no-cache --watch ./*",
@@ -66,4 +67,3 @@
   ],
   "dependencies": {}
 }
-

--- a/exercises/wordy/package.json
+++ b/exercises/wordy/package.json
@@ -9,7 +9,7 @@
     "url": "https://github.com/exercism/xecmascript"
   },
   "devDependencies": {
-    "babel-jest": "^20.0.1",
+    "babel-jest": "^20.0.3",
     "babel-plugin-transform-builtin-extend": "^1.1.2",
     "babel-preset-env": "^1.4.0",
     "eslint": "^3.19.0",
@@ -17,7 +17,7 @@
     "eslint-plugin-import": "^2.2.0",
     "eslint-plugin-jsx-a11y": "^5.0.1",
     "eslint-plugin-react": "^7.0.1",
-    "jest": "^20.0.1"
+    "jest": "^20.0.4"
   },
   "jest": {
     "modulePathIgnorePatterns": [
@@ -36,9 +36,10 @@
             "Error"
           ]
         }
-      ]
+      ],
+      ["transform-regenerator"]
     ]
-  },
+},
   "scripts": {
     "test": "jest --no-cache ./*",
     "watch": "jest --no-cache --watch ./*",
@@ -66,4 +67,3 @@
   ],
   "dependencies": {}
 }
-

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "url": "https://github.com/exercism/xecmascript"
   },
   "devDependencies": {
-    "babel-jest": "^20.0.1",
+    "babel-jest": "^20.0.3",
     "babel-plugin-transform-builtin-extend": "^1.1.2",
     "babel-preset-env": "^1.4.0",
     "eslint": "^3.19.0",
@@ -17,7 +17,7 @@
     "eslint-plugin-import": "^2.2.0",
     "eslint-plugin-jsx-a11y": "^5.0.1",
     "eslint-plugin-react": "^7.0.1",
-    "jest": "^20.0.1"
+    "jest": "^20.0.4"
   },
   "jest": {
     "modulePathIgnorePatterns": [
@@ -36,9 +36,10 @@
             "Error"
           ]
         }
-      ]
+      ],
+      ["transform-regenerator"]
     ]
-  },
+},
   "scripts": {
     "test": "jest --no-cache ./*",
     "watch": "jest --no-cache --watch ./*",
@@ -66,4 +67,3 @@
   ],
   "dependencies": {}
 }
-

--- a/yarn.lock
+++ b/yarn.lock
@@ -90,6 +90,12 @@ argparse@^1.0.7:
   dependencies:
     sprintf-js "~1.0.2"
 
+aria-query@^0.7.0:
+  version "0.7.0"
+  resolved "https://registry.yarnpkg.com/aria-query/-/aria-query-0.7.0.tgz#4af10a1e61573ddea0cf3b99b51c52c05b424d24"
+  dependencies:
+    ast-types-flow "0.0.7"
+
 arr-diff@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/arr-diff/-/arr-diff-2.0.0.tgz#8f3b827f955a8bd669697e4a4256ac3ceae356cf"
@@ -103,6 +109,13 @@ arr-flatten@^1.0.1:
 array-equal@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/array-equal/-/array-equal-1.0.0.tgz#8c2a5ef2472fd9ea742b04c77a75093ba2757c93"
+
+array-includes@^3.0.3:
+  version "3.0.3"
+  resolved "https://registry.yarnpkg.com/array-includes/-/array-includes-3.0.3.tgz#184b48f62d92d7452bb31b323165c7f8bd02266d"
+  dependencies:
+    define-properties "^1.1.2"
+    es-abstract "^1.7.0"
 
 array-union@^1.0.1:
   version "1.0.2"
@@ -134,6 +147,10 @@ assert-plus@^0.2.0:
   version "0.2.0"
   resolved "https://registry.yarnpkg.com/assert-plus/-/assert-plus-0.2.0.tgz#d74e1b87e7affc0db8aadb7021f3fe48101ab234"
 
+ast-types-flow@0.0.7:
+  version "0.0.7"
+  resolved "https://registry.yarnpkg.com/ast-types-flow/-/ast-types-flow-0.0.7.tgz#f70b735c6bca1a5c9c22d982c3e39e7feba3bdad"
+
 async@^1.4.0:
   version "1.5.2"
   resolved "https://registry.yarnpkg.com/async/-/async-1.5.2.tgz#ec6a61ae56480c0c3cb241c95618e20892f9672a"
@@ -155,6 +172,12 @@ aws-sign2@~0.6.0:
 aws4@^1.2.1:
   version "1.6.0"
   resolved "https://registry.yarnpkg.com/aws4/-/aws4-1.6.0.tgz#83ef5ca860b2b32e4a0deedee8c771b9db57471e"
+
+axobject-query@^0.1.0:
+  version "0.1.0"
+  resolved "https://registry.yarnpkg.com/axobject-query/-/axobject-query-0.1.0.tgz#62f59dbc59c9f9242759ca349960e7a2fe3c36c0"
+  dependencies:
+    ast-types-flow "0.0.7"
 
 babel-code-frame@^6.16.0, babel-code-frame@^6.22.0:
   version "6.22.0"
@@ -302,13 +325,13 @@ babel-helpers@^6.24.1:
     babel-runtime "^6.22.0"
     babel-template "^6.24.1"
 
-babel-jest@^20.0.1:
-  version "20.0.1"
-  resolved "https://registry.yarnpkg.com/babel-jest/-/babel-jest-20.0.1.tgz#9cbe9a15bbe3f1ca1b727dc8e45a4161771d3655"
+babel-jest@^20.0.3:
+  version "20.0.3"
+  resolved "https://registry.yarnpkg.com/babel-jest/-/babel-jest-20.0.3.tgz#e4a03b13dc10389e140fc645d09ffc4ced301671"
   dependencies:
     babel-core "^6.0.0"
     babel-plugin-istanbul "^4.0.0"
-    babel-preset-jest "^20.0.1"
+    babel-preset-jest "^20.0.3"
 
 babel-messages@^6.23.0:
   version "6.23.0"
@@ -330,9 +353,9 @@ babel-plugin-istanbul@^4.0.0:
     istanbul-lib-instrument "^1.7.1"
     test-exclude "^4.1.0"
 
-babel-plugin-jest-hoist@^20.0.1:
-  version "20.0.1"
-  resolved "https://registry.yarnpkg.com/babel-plugin-jest-hoist/-/babel-plugin-jest-hoist-20.0.1.tgz#1b9cc322cff704d3812d1bca8dccd12205eedfd5"
+babel-plugin-jest-hoist@^20.0.3:
+  version "20.0.3"
+  resolved "https://registry.yarnpkg.com/babel-plugin-jest-hoist/-/babel-plugin-jest-hoist-20.0.3.tgz#afedc853bd3f8dc3548ea671fbe69d03cc2c1767"
 
 babel-plugin-syntax-async-functions@^6.8.0:
   version "6.13.0"
@@ -373,7 +396,7 @@ babel-plugin-transform-es2015-block-scoped-functions@^6.22.0:
   dependencies:
     babel-runtime "^6.22.0"
 
-babel-plugin-transform-es2015-block-scoping@^6.23.0:
+babel-plugin-transform-es2015-block-scoping@^6.23.0, babel-plugin-transform-es2015-block-scoping@^6.24.1:
   version "6.24.1"
   resolved "https://registry.yarnpkg.com/babel-plugin-transform-es2015-block-scoping/-/babel-plugin-transform-es2015-block-scoping-6.24.1.tgz#76c295dc3a4741b1665adfd3167215dcff32a576"
   dependencies:
@@ -383,7 +406,7 @@ babel-plugin-transform-es2015-block-scoping@^6.23.0:
     babel-types "^6.24.1"
     lodash "^4.2.0"
 
-babel-plugin-transform-es2015-classes@^6.23.0:
+babel-plugin-transform-es2015-classes@^6.23.0, babel-plugin-transform-es2015-classes@^6.24.1:
   version "6.24.1"
   resolved "https://registry.yarnpkg.com/babel-plugin-transform-es2015-classes/-/babel-plugin-transform-es2015-classes-6.24.1.tgz#5a4c58a50c9c9461e564b4b2a3bfabc97a2584db"
   dependencies:
@@ -397,33 +420,33 @@ babel-plugin-transform-es2015-classes@^6.23.0:
     babel-traverse "^6.24.1"
     babel-types "^6.24.1"
 
-babel-plugin-transform-es2015-computed-properties@^6.22.0:
+babel-plugin-transform-es2015-computed-properties@^6.22.0, babel-plugin-transform-es2015-computed-properties@^6.24.1:
   version "6.24.1"
   resolved "https://registry.yarnpkg.com/babel-plugin-transform-es2015-computed-properties/-/babel-plugin-transform-es2015-computed-properties-6.24.1.tgz#6fe2a8d16895d5634f4cd999b6d3480a308159b3"
   dependencies:
     babel-runtime "^6.22.0"
     babel-template "^6.24.1"
 
-babel-plugin-transform-es2015-destructuring@^6.23.0:
+babel-plugin-transform-es2015-destructuring@^6.22.0, babel-plugin-transform-es2015-destructuring@^6.23.0:
   version "6.23.0"
   resolved "https://registry.yarnpkg.com/babel-plugin-transform-es2015-destructuring/-/babel-plugin-transform-es2015-destructuring-6.23.0.tgz#997bb1f1ab967f682d2b0876fe358d60e765c56d"
   dependencies:
     babel-runtime "^6.22.0"
 
-babel-plugin-transform-es2015-duplicate-keys@^6.22.0:
+babel-plugin-transform-es2015-duplicate-keys@^6.22.0, babel-plugin-transform-es2015-duplicate-keys@^6.24.1:
   version "6.24.1"
   resolved "https://registry.yarnpkg.com/babel-plugin-transform-es2015-duplicate-keys/-/babel-plugin-transform-es2015-duplicate-keys-6.24.1.tgz#73eb3d310ca969e3ef9ec91c53741a6f1576423e"
   dependencies:
     babel-runtime "^6.22.0"
     babel-types "^6.24.1"
 
-babel-plugin-transform-es2015-for-of@^6.23.0:
+babel-plugin-transform-es2015-for-of@^6.22.0, babel-plugin-transform-es2015-for-of@^6.23.0:
   version "6.23.0"
   resolved "https://registry.yarnpkg.com/babel-plugin-transform-es2015-for-of/-/babel-plugin-transform-es2015-for-of-6.23.0.tgz#f47c95b2b613df1d3ecc2fdb7573623c75248691"
   dependencies:
     babel-runtime "^6.22.0"
 
-babel-plugin-transform-es2015-function-name@^6.22.0:
+babel-plugin-transform-es2015-function-name@^6.22.0, babel-plugin-transform-es2015-function-name@^6.24.1:
   version "6.24.1"
   resolved "https://registry.yarnpkg.com/babel-plugin-transform-es2015-function-name/-/babel-plugin-transform-es2015-function-name-6.24.1.tgz#834c89853bc36b1af0f3a4c5dbaa94fd8eacaa8b"
   dependencies:
@@ -454,7 +477,7 @@ babel-plugin-transform-es2015-modules-commonjs@^6.23.0, babel-plugin-transform-e
     babel-template "^6.24.1"
     babel-types "^6.24.1"
 
-babel-plugin-transform-es2015-modules-systemjs@^6.23.0:
+babel-plugin-transform-es2015-modules-systemjs@^6.23.0, babel-plugin-transform-es2015-modules-systemjs@^6.24.1:
   version "6.24.1"
   resolved "https://registry.yarnpkg.com/babel-plugin-transform-es2015-modules-systemjs/-/babel-plugin-transform-es2015-modules-systemjs-6.24.1.tgz#ff89a142b9119a906195f5f106ecf305d9407d23"
   dependencies:
@@ -462,7 +485,7 @@ babel-plugin-transform-es2015-modules-systemjs@^6.23.0:
     babel-runtime "^6.22.0"
     babel-template "^6.24.1"
 
-babel-plugin-transform-es2015-modules-umd@^6.23.0:
+babel-plugin-transform-es2015-modules-umd@^6.23.0, babel-plugin-transform-es2015-modules-umd@^6.24.1:
   version "6.24.1"
   resolved "https://registry.yarnpkg.com/babel-plugin-transform-es2015-modules-umd/-/babel-plugin-transform-es2015-modules-umd-6.24.1.tgz#ac997e6285cd18ed6176adb607d602344ad38468"
   dependencies:
@@ -470,14 +493,14 @@ babel-plugin-transform-es2015-modules-umd@^6.23.0:
     babel-runtime "^6.22.0"
     babel-template "^6.24.1"
 
-babel-plugin-transform-es2015-object-super@^6.22.0:
+babel-plugin-transform-es2015-object-super@^6.22.0, babel-plugin-transform-es2015-object-super@^6.24.1:
   version "6.24.1"
   resolved "https://registry.yarnpkg.com/babel-plugin-transform-es2015-object-super/-/babel-plugin-transform-es2015-object-super-6.24.1.tgz#24cef69ae21cb83a7f8603dad021f572eb278f8d"
   dependencies:
     babel-helper-replace-supers "^6.24.1"
     babel-runtime "^6.22.0"
 
-babel-plugin-transform-es2015-parameters@^6.23.0:
+babel-plugin-transform-es2015-parameters@^6.23.0, babel-plugin-transform-es2015-parameters@^6.24.1:
   version "6.24.1"
   resolved "https://registry.yarnpkg.com/babel-plugin-transform-es2015-parameters/-/babel-plugin-transform-es2015-parameters-6.24.1.tgz#57ac351ab49caf14a97cd13b09f66fdf0a625f2b"
   dependencies:
@@ -488,7 +511,7 @@ babel-plugin-transform-es2015-parameters@^6.23.0:
     babel-traverse "^6.24.1"
     babel-types "^6.24.1"
 
-babel-plugin-transform-es2015-shorthand-properties@^6.22.0:
+babel-plugin-transform-es2015-shorthand-properties@^6.22.0, babel-plugin-transform-es2015-shorthand-properties@^6.24.1:
   version "6.24.1"
   resolved "https://registry.yarnpkg.com/babel-plugin-transform-es2015-shorthand-properties/-/babel-plugin-transform-es2015-shorthand-properties-6.24.1.tgz#24f875d6721c87661bbd99a4622e51f14de38aa0"
   dependencies:
@@ -501,7 +524,7 @@ babel-plugin-transform-es2015-spread@^6.22.0:
   dependencies:
     babel-runtime "^6.22.0"
 
-babel-plugin-transform-es2015-sticky-regex@^6.22.0:
+babel-plugin-transform-es2015-sticky-regex@^6.22.0, babel-plugin-transform-es2015-sticky-regex@^6.24.1:
   version "6.24.1"
   resolved "https://registry.yarnpkg.com/babel-plugin-transform-es2015-sticky-regex/-/babel-plugin-transform-es2015-sticky-regex-6.24.1.tgz#00c1cdb1aca71112cdf0cf6126c2ed6b457ccdbc"
   dependencies:
@@ -515,13 +538,13 @@ babel-plugin-transform-es2015-template-literals@^6.22.0:
   dependencies:
     babel-runtime "^6.22.0"
 
-babel-plugin-transform-es2015-typeof-symbol@^6.23.0:
+babel-plugin-transform-es2015-typeof-symbol@^6.22.0, babel-plugin-transform-es2015-typeof-symbol@^6.23.0:
   version "6.23.0"
   resolved "https://registry.yarnpkg.com/babel-plugin-transform-es2015-typeof-symbol/-/babel-plugin-transform-es2015-typeof-symbol-6.23.0.tgz#dec09f1cddff94b52ac73d505c84df59dcceb372"
   dependencies:
     babel-runtime "^6.22.0"
 
-babel-plugin-transform-es2015-unicode-regex@^6.22.0:
+babel-plugin-transform-es2015-unicode-regex@^6.22.0, babel-plugin-transform-es2015-unicode-regex@^6.24.1:
   version "6.24.1"
   resolved "https://registry.yarnpkg.com/babel-plugin-transform-es2015-unicode-regex/-/babel-plugin-transform-es2015-unicode-regex-6.24.1.tgz#d38b12f42ea7323f729387f18a7c5ae1faeb35e9"
   dependencies:
@@ -537,7 +560,7 @@ babel-plugin-transform-exponentiation-operator@^6.22.0:
     babel-plugin-syntax-exponentiation-operator "^6.8.0"
     babel-runtime "^6.22.0"
 
-babel-plugin-transform-regenerator@^6.22.0:
+babel-plugin-transform-regenerator@^6.22.0, babel-plugin-transform-regenerator@^6.24.1:
   version "6.24.1"
   resolved "https://registry.yarnpkg.com/babel-plugin-transform-regenerator/-/babel-plugin-transform-regenerator-6.24.1.tgz#b8da305ad43c3c99b4848e4fe4037b770d23c418"
   dependencies:
@@ -584,11 +607,40 @@ babel-preset-env@^1.4.0:
     browserslist "^1.4.0"
     invariant "^2.2.2"
 
-babel-preset-jest@^20.0.1:
-  version "20.0.1"
-  resolved "https://registry.yarnpkg.com/babel-preset-jest/-/babel-preset-jest-20.0.1.tgz#8a9e23ce8a0f0c49835de53ed73ecf75dd6daa2e"
+babel-preset-es2015@^6.24.1:
+  version "6.24.1"
+  resolved "https://registry.yarnpkg.com/babel-preset-es2015/-/babel-preset-es2015-6.24.1.tgz#d44050d6bc2c9feea702aaf38d727a0210538939"
   dependencies:
-    babel-plugin-jest-hoist "^20.0.1"
+    babel-plugin-check-es2015-constants "^6.22.0"
+    babel-plugin-transform-es2015-arrow-functions "^6.22.0"
+    babel-plugin-transform-es2015-block-scoped-functions "^6.22.0"
+    babel-plugin-transform-es2015-block-scoping "^6.24.1"
+    babel-plugin-transform-es2015-classes "^6.24.1"
+    babel-plugin-transform-es2015-computed-properties "^6.24.1"
+    babel-plugin-transform-es2015-destructuring "^6.22.0"
+    babel-plugin-transform-es2015-duplicate-keys "^6.24.1"
+    babel-plugin-transform-es2015-for-of "^6.22.0"
+    babel-plugin-transform-es2015-function-name "^6.24.1"
+    babel-plugin-transform-es2015-literals "^6.22.0"
+    babel-plugin-transform-es2015-modules-amd "^6.24.1"
+    babel-plugin-transform-es2015-modules-commonjs "^6.24.1"
+    babel-plugin-transform-es2015-modules-systemjs "^6.24.1"
+    babel-plugin-transform-es2015-modules-umd "^6.24.1"
+    babel-plugin-transform-es2015-object-super "^6.24.1"
+    babel-plugin-transform-es2015-parameters "^6.24.1"
+    babel-plugin-transform-es2015-shorthand-properties "^6.24.1"
+    babel-plugin-transform-es2015-spread "^6.22.0"
+    babel-plugin-transform-es2015-sticky-regex "^6.24.1"
+    babel-plugin-transform-es2015-template-literals "^6.22.0"
+    babel-plugin-transform-es2015-typeof-symbol "^6.22.0"
+    babel-plugin-transform-es2015-unicode-regex "^6.24.1"
+    babel-plugin-transform-regenerator "^6.24.1"
+
+babel-preset-jest@^20.0.3:
+  version "20.0.3"
+  resolved "https://registry.yarnpkg.com/babel-preset-jest/-/babel-preset-jest-20.0.3.tgz#cbacaadecb5d689ca1e1de1360ebfc66862c178a"
+  dependencies:
+    babel-plugin-jest-hoist "^20.0.3"
 
 babel-register@^6.24.1:
   version "6.24.1"
@@ -706,7 +758,7 @@ buffer-shims@~1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/buffer-shims/-/buffer-shims-1.0.0.tgz#9978ce317388c649ad8793028c3477ef044a8b51"
 
-builtin-modules@^1.0.0:
+builtin-modules@^1.0.0, builtin-modules@^1.1.1:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/builtin-modules/-/builtin-modules-1.1.1.tgz#270f076c5a72c02f5b65a47df94c5fe3a278892f"
 
@@ -827,6 +879,10 @@ concat-stream@^1.5.2:
     readable-stream "^2.2.2"
     typedarray "^0.0.6"
 
+contains-path@^0.1.0:
+  version "0.1.0"
+  resolved "https://registry.yarnpkg.com/contains-path/-/contains-path-0.1.0.tgz#fe8cf184ff6670b6baef01a9d4861a5cbec4120a"
+
 content-type-parser@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/content-type-parser/-/content-type-parser-1.0.1.tgz#c3e56988c53c65127fb46d4032a3a900246fdc94"
@@ -865,17 +921,27 @@ d@1:
   dependencies:
     es5-ext "^0.10.9"
 
+damerau-levenshtein@^1.0.0:
+  version "1.0.4"
+  resolved "https://registry.yarnpkg.com/damerau-levenshtein/-/damerau-levenshtein-1.0.4.tgz#03191c432cb6eea168bb77f3a55ffdccb8978514"
+
 dashdash@^1.12.0:
   version "1.14.1"
   resolved "https://registry.yarnpkg.com/dashdash/-/dashdash-1.14.1.tgz#853cfa0f7cbe2fed5de20326b8dd581035f6e2f0"
   dependencies:
     assert-plus "^1.0.0"
 
-debug@^2.1.1, debug@^2.2.0, debug@^2.6.3:
+debug@^2.1.1:
   version "2.6.6"
   resolved "https://registry.yarnpkg.com/debug/-/debug-2.6.6.tgz#a9fa6fbe9ca43cf1e79f73b75c0189cbb7d6db5a"
   dependencies:
     ms "0.7.3"
+
+debug@^2.2.0, debug@^2.6.3, debug@^2.6.8:
+  version "2.6.8"
+  resolved "https://registry.yarnpkg.com/debug/-/debug-2.6.8.tgz#e731531ca2ede27d188222427da17821d68ff4fc"
+  dependencies:
+    ms "2.0.0"
 
 decamelize@^1.0.0, decamelize@^1.1.1:
   version "1.2.0"
@@ -890,6 +956,13 @@ default-require-extensions@^1.0.0:
   resolved "https://registry.yarnpkg.com/default-require-extensions/-/default-require-extensions-1.0.0.tgz#f37ea15d3e13ffd9b437d33e1a75b5fb97874cb8"
   dependencies:
     strip-bom "^2.0.0"
+
+define-properties@^1.1.2:
+  version "1.1.2"
+  resolved "https://registry.yarnpkg.com/define-properties/-/define-properties-1.1.2.tgz#83a73f2fea569898fb737193c8f873caf6d45c94"
+  dependencies:
+    foreach "^2.0.5"
+    object-keys "^1.0.8"
 
 del@^2.0.2:
   version "2.2.2"
@@ -917,6 +990,13 @@ diff@^3.2.0:
   version "3.2.0"
   resolved "https://registry.yarnpkg.com/diff/-/diff-3.2.0.tgz#c9ce393a4b7cbd0b058a725c93df299027868ff9"
 
+doctrine@1.5.0:
+  version "1.5.0"
+  resolved "https://registry.yarnpkg.com/doctrine/-/doctrine-1.5.0.tgz#379dce730f6166f76cefa4e6707a159b02c5a6fa"
+  dependencies:
+    esutils "^2.0.2"
+    isarray "^1.0.0"
+
 doctrine@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/doctrine/-/doctrine-2.0.0.tgz#c73d8d2909d22291e1a007a395804da8b665fe63"
@@ -934,6 +1014,10 @@ electron-to-chromium@^1.2.7:
   version "1.3.10"
   resolved "https://registry.yarnpkg.com/electron-to-chromium/-/electron-to-chromium-1.3.10.tgz#63d62b785471f0d8dda85199d64579de8a449f08"
 
+emoji-regex@^6.1.0:
+  version "6.5.1"
+  resolved "https://registry.yarnpkg.com/emoji-regex/-/emoji-regex-6.5.1.tgz#9baea929b155565c11ea41c6626eaa65cef992c2"
+
 "errno@>=0.1.1 <0.2.0-0":
   version "0.1.4"
   resolved "https://registry.yarnpkg.com/errno/-/errno-0.1.4.tgz#b896e23a9e5e8ba33871fc996abd3635fc9a1c7d"
@@ -945,6 +1029,24 @@ error-ex@^1.2.0:
   resolved "https://registry.yarnpkg.com/error-ex/-/error-ex-1.3.1.tgz#f855a86ce61adc4e8621c3cda21e7a7612c3a8dc"
   dependencies:
     is-arrayish "^0.2.1"
+
+es-abstract@^1.7.0:
+  version "1.8.0"
+  resolved "https://registry.yarnpkg.com/es-abstract/-/es-abstract-1.8.0.tgz#3b00385e85729932beffa9163bbea1234e932914"
+  dependencies:
+    es-to-primitive "^1.1.1"
+    function-bind "^1.1.0"
+    has "^1.0.1"
+    is-callable "^1.1.3"
+    is-regex "^1.0.4"
+
+es-to-primitive@^1.1.1:
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/es-to-primitive/-/es-to-primitive-1.1.1.tgz#45355248a88979034b6792e19bb81f2b7975dd0d"
+  dependencies:
+    is-callable "^1.1.1"
+    is-date-object "^1.0.1"
+    is-symbol "^1.0.1"
 
 es5-ext@^0.10.14, es5-ext@^0.10.9, es5-ext@~0.10.14:
   version "0.10.16"
@@ -1021,6 +1123,71 @@ escope@^3.6.0:
     es6-weak-map "^2.0.1"
     esrecurse "^4.1.0"
     estraverse "^4.1.1"
+
+eslint-config-airbnb-base@^11.3.0:
+  version "11.3.1"
+  resolved "https://registry.yarnpkg.com/eslint-config-airbnb-base/-/eslint-config-airbnb-base-11.3.1.tgz#c0ab108c9beed503cb999e4c60f4ef98eda0ed30"
+  dependencies:
+    eslint-restricted-globals "^0.1.1"
+
+eslint-config-airbnb@^15.0.1:
+  version "15.1.0"
+  resolved "https://registry.yarnpkg.com/eslint-config-airbnb/-/eslint-config-airbnb-15.1.0.tgz#fd432965a906e30139001ba830f58f73aeddae8e"
+  dependencies:
+    eslint-config-airbnb-base "^11.3.0"
+
+eslint-import-resolver-node@^0.3.1:
+  version "0.3.1"
+  resolved "https://registry.yarnpkg.com/eslint-import-resolver-node/-/eslint-import-resolver-node-0.3.1.tgz#4422574cde66a9a7b099938ee4d508a199e0e3cc"
+  dependencies:
+    debug "^2.6.8"
+    resolve "^1.2.0"
+
+eslint-module-utils@^2.1.1:
+  version "2.1.1"
+  resolved "https://registry.yarnpkg.com/eslint-module-utils/-/eslint-module-utils-2.1.1.tgz#abaec824177613b8a95b299639e1b6facf473449"
+  dependencies:
+    debug "^2.6.8"
+    pkg-dir "^1.0.0"
+
+eslint-plugin-import@^2.2.0:
+  version "2.7.0"
+  resolved "https://registry.yarnpkg.com/eslint-plugin-import/-/eslint-plugin-import-2.7.0.tgz#21de33380b9efb55f5ef6d2e210ec0e07e7fa69f"
+  dependencies:
+    builtin-modules "^1.1.1"
+    contains-path "^0.1.0"
+    debug "^2.6.8"
+    doctrine "1.5.0"
+    eslint-import-resolver-node "^0.3.1"
+    eslint-module-utils "^2.1.1"
+    has "^1.0.1"
+    lodash.cond "^4.3.0"
+    minimatch "^3.0.3"
+    read-pkg-up "^2.0.0"
+
+eslint-plugin-jsx-a11y@^5.0.1:
+  version "5.1.1"
+  resolved "https://registry.yarnpkg.com/eslint-plugin-jsx-a11y/-/eslint-plugin-jsx-a11y-5.1.1.tgz#5c96bb5186ca14e94db1095ff59b3e2bd94069b1"
+  dependencies:
+    aria-query "^0.7.0"
+    array-includes "^3.0.3"
+    ast-types-flow "0.0.7"
+    axobject-query "^0.1.0"
+    damerau-levenshtein "^1.0.0"
+    emoji-regex "^6.1.0"
+    jsx-ast-utils "^1.4.0"
+
+eslint-plugin-react@^7.0.1:
+  version "7.1.0"
+  resolved "https://registry.yarnpkg.com/eslint-plugin-react/-/eslint-plugin-react-7.1.0.tgz#27770acf39f5fd49cd0af4083ce58104eb390d4c"
+  dependencies:
+    doctrine "^2.0.0"
+    has "^1.0.1"
+    jsx-ast-utils "^1.4.1"
+
+eslint-restricted-globals@^0.1.1:
+  version "0.1.1"
+  resolved "https://registry.yarnpkg.com/eslint-restricted-globals/-/eslint-restricted-globals-0.1.1.tgz#35f0d5cbc64c2e3ed62e93b4b1a7af05ba7ed4d7"
 
 eslint@^3.19.0:
   version "3.19.0"
@@ -1207,7 +1374,7 @@ find-up@^1.0.0:
     path-exists "^2.0.0"
     pinkie-promise "^2.0.0"
 
-find-up@^2.1.0:
+find-up@^2.0.0, find-up@^2.1.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/find-up/-/find-up-2.1.0.tgz#45d1b7e506c717ddd482775a2b77920a3c0c57a7"
   dependencies:
@@ -1232,6 +1399,10 @@ for-own@^0.1.4:
   dependencies:
     for-in "^1.0.1"
 
+foreach@^2.0.5:
+  version "2.0.5"
+  resolved "https://registry.yarnpkg.com/foreach/-/foreach-2.0.5.tgz#0bee005018aeb260d0a3af3ae658dd0136ec1b99"
+
 forever-agent@~0.6.1:
   version "0.6.1"
   resolved "https://registry.yarnpkg.com/forever-agent/-/forever-agent-0.6.1.tgz#fbc71f0c41adeb37f96c577ad1ed42d8fdacca91"
@@ -1247,6 +1418,10 @@ form-data@~2.1.1:
 fs.realpath@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/fs.realpath/-/fs.realpath-1.0.0.tgz#1504ad2523158caa40db4a2787cb01411994ea4f"
+
+function-bind@^1.0.2, function-bind@^1.1.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/function-bind/-/function-bind-1.1.0.tgz#16176714c801798e4e8f2cf7f7529467bb4a5771"
 
 generate-function@^2.0.0:
   version "2.0.0"
@@ -1345,6 +1520,12 @@ has-ansi@^2.0.0:
 has-flag@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/has-flag/-/has-flag-1.0.0.tgz#9d9e793165ce017a00f00418c43f942a7b1d11fa"
+
+has@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/has/-/has-1.0.1.tgz#8461733f538b0837c9361e39a9ab9e9704dc2f28"
+  dependencies:
+    function-bind "^1.0.2"
 
 hawk@~3.1.3:
   version "3.1.3"
@@ -1453,11 +1634,19 @@ is-builtin-module@^1.0.0:
   dependencies:
     builtin-modules "^1.0.0"
 
+is-callable@^1.1.1, is-callable@^1.1.3:
+  version "1.1.3"
+  resolved "https://registry.yarnpkg.com/is-callable/-/is-callable-1.1.3.tgz#86eb75392805ddc33af71c92a0eedf74ee7604b2"
+
 is-ci@^1.0.10:
   version "1.0.10"
   resolved "https://registry.yarnpkg.com/is-ci/-/is-ci-1.0.10.tgz#f739336b2632365061a9d48270cd56ae3369318e"
   dependencies:
     ci-info "^1.0.0"
+
+is-date-object@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/is-date-object/-/is-date-object-1.0.1.tgz#9aa20eb6aeebbff77fbd33e74ca01b33581d3a16"
 
 is-dotfile@^1.0.0:
   version "1.0.2"
@@ -1542,11 +1731,21 @@ is-property@^1.0.0:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/is-property/-/is-property-1.0.2.tgz#57fe1c4e48474edd65b09911f26b1cd4095dda84"
 
+is-regex@^1.0.4:
+  version "1.0.4"
+  resolved "https://registry.yarnpkg.com/is-regex/-/is-regex-1.0.4.tgz#5517489b547091b0930e095654ced25ee97e9491"
+  dependencies:
+    has "^1.0.1"
+
 is-resolvable@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/is-resolvable/-/is-resolvable-1.0.0.tgz#8df57c61ea2e3c501408d100fb013cf8d6e0cc62"
   dependencies:
     tryit "^1.0.1"
+
+is-symbol@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/is-symbol/-/is-symbol-1.0.1.tgz#3cc59f00025194b6ab2e38dbae6689256b660572"
 
 is-typedarray@~1.0.0:
   version "1.0.0"
@@ -1637,13 +1836,13 @@ istanbul-reports@^1.1.0:
   dependencies:
     handlebars "^4.0.3"
 
-jest-changed-files@^20.0.1:
-  version "20.0.1"
-  resolved "https://registry.yarnpkg.com/jest-changed-files/-/jest-changed-files-20.0.1.tgz#ba9bd42c3fddb1b7c4ae40065199b44a2335e152"
+jest-changed-files@^20.0.3:
+  version "20.0.3"
+  resolved "https://registry.yarnpkg.com/jest-changed-files/-/jest-changed-files-20.0.3.tgz#9394d5cc65c438406149bef1bf4d52b68e03e3f8"
 
-jest-cli@^20.0.1:
-  version "20.0.1"
-  resolved "https://registry.yarnpkg.com/jest-cli/-/jest-cli-20.0.1.tgz#86ca0bc2e47215ad8e7dc85455c0210f86648502"
+jest-cli@^20.0.4:
+  version "20.0.4"
+  resolved "https://registry.yarnpkg.com/jest-cli/-/jest-cli-20.0.4.tgz#e532b19d88ae5bc6c417e8b0593a6fe954b1dc93"
   dependencies:
     ansi-escapes "^1.4.0"
     callsites "^2.0.0"
@@ -1654,18 +1853,18 @@ jest-cli@^20.0.1:
     istanbul-lib-coverage "^1.0.1"
     istanbul-lib-instrument "^1.4.2"
     istanbul-lib-source-maps "^1.1.0"
-    jest-changed-files "^20.0.1"
-    jest-config "^20.0.1"
-    jest-docblock "^20.0.1"
-    jest-environment-jsdom "^20.0.1"
-    jest-haste-map "^20.0.1"
-    jest-jasmine2 "^20.0.1"
-    jest-message-util "^20.0.1"
-    jest-regex-util "^20.0.1"
-    jest-resolve-dependencies "^20.0.1"
-    jest-runtime "^20.0.1"
-    jest-snapshot "^20.0.1"
-    jest-util "^20.0.1"
+    jest-changed-files "^20.0.3"
+    jest-config "^20.0.4"
+    jest-docblock "^20.0.3"
+    jest-environment-jsdom "^20.0.3"
+    jest-haste-map "^20.0.4"
+    jest-jasmine2 "^20.0.4"
+    jest-message-util "^20.0.3"
+    jest-regex-util "^20.0.3"
+    jest-resolve-dependencies "^20.0.3"
+    jest-runtime "^20.0.4"
+    jest-snapshot "^20.0.3"
+    jest-util "^20.0.3"
     micromatch "^2.3.11"
     node-notifier "^5.0.2"
     pify "^2.3.0"
@@ -1676,177 +1875,177 @@ jest-cli@^20.0.1:
     worker-farm "^1.3.1"
     yargs "^7.0.2"
 
-jest-config@^20.0.1:
-  version "20.0.1"
-  resolved "https://registry.yarnpkg.com/jest-config/-/jest-config-20.0.1.tgz#c6934f585c3e1775c96133efb302f986c3909ad8"
+jest-config@^20.0.4:
+  version "20.0.4"
+  resolved "https://registry.yarnpkg.com/jest-config/-/jest-config-20.0.4.tgz#e37930ab2217c913605eff13e7bd763ec48faeea"
   dependencies:
     chalk "^1.1.3"
     glob "^7.1.1"
-    jest-environment-jsdom "^20.0.1"
-    jest-environment-node "^20.0.1"
-    jest-jasmine2 "^20.0.1"
-    jest-matcher-utils "^20.0.1"
-    jest-regex-util "^20.0.1"
-    jest-resolve "^20.0.1"
-    jest-validate "^20.0.1"
-    pretty-format "^20.0.1"
+    jest-environment-jsdom "^20.0.3"
+    jest-environment-node "^20.0.3"
+    jest-jasmine2 "^20.0.4"
+    jest-matcher-utils "^20.0.3"
+    jest-regex-util "^20.0.3"
+    jest-resolve "^20.0.4"
+    jest-validate "^20.0.3"
+    pretty-format "^20.0.3"
 
-jest-diff@^20.0.1:
-  version "20.0.1"
-  resolved "https://registry.yarnpkg.com/jest-diff/-/jest-diff-20.0.1.tgz#2567c80c324243328321386f8871a28ec9d350ac"
+jest-diff@^20.0.3:
+  version "20.0.3"
+  resolved "https://registry.yarnpkg.com/jest-diff/-/jest-diff-20.0.3.tgz#81f288fd9e675f0fb23c75f1c2b19445fe586617"
   dependencies:
     chalk "^1.1.3"
     diff "^3.2.0"
-    jest-matcher-utils "^20.0.1"
-    pretty-format "^20.0.1"
+    jest-matcher-utils "^20.0.3"
+    pretty-format "^20.0.3"
 
-jest-docblock@^20.0.1:
-  version "20.0.1"
-  resolved "https://registry.yarnpkg.com/jest-docblock/-/jest-docblock-20.0.1.tgz#055e0bbcb76798198479901f92d2733bf619f854"
+jest-docblock@^20.0.3:
+  version "20.0.3"
+  resolved "https://registry.yarnpkg.com/jest-docblock/-/jest-docblock-20.0.3.tgz#17bea984342cc33d83c50fbe1545ea0efaa44712"
 
-jest-environment-jsdom@^20.0.1:
-  version "20.0.1"
-  resolved "https://registry.yarnpkg.com/jest-environment-jsdom/-/jest-environment-jsdom-20.0.1.tgz#2d29f81368987d387c70ce4f500c6aa560f9b4f7"
+jest-environment-jsdom@^20.0.3:
+  version "20.0.3"
+  resolved "https://registry.yarnpkg.com/jest-environment-jsdom/-/jest-environment-jsdom-20.0.3.tgz#048a8ac12ee225f7190417713834bb999787de99"
   dependencies:
-    jest-mock "^20.0.1"
-    jest-util "^20.0.1"
+    jest-mock "^20.0.3"
+    jest-util "^20.0.3"
     jsdom "^9.12.0"
 
-jest-environment-node@^20.0.1:
-  version "20.0.1"
-  resolved "https://registry.yarnpkg.com/jest-environment-node/-/jest-environment-node-20.0.1.tgz#75ab5358072ee1efebc54f43474357d7b3d674c7"
+jest-environment-node@^20.0.3:
+  version "20.0.3"
+  resolved "https://registry.yarnpkg.com/jest-environment-node/-/jest-environment-node-20.0.3.tgz#d488bc4612af2c246e986e8ae7671a099163d403"
   dependencies:
-    jest-mock "^20.0.1"
-    jest-util "^20.0.1"
+    jest-mock "^20.0.3"
+    jest-util "^20.0.3"
 
-jest-haste-map@^20.0.1:
-  version "20.0.1"
-  resolved "https://registry.yarnpkg.com/jest-haste-map/-/jest-haste-map-20.0.1.tgz#e6ba4db99ab512e7c081a5b0a0af731d0e193d56"
+jest-haste-map@^20.0.4:
+  version "20.0.5"
+  resolved "https://registry.yarnpkg.com/jest-haste-map/-/jest-haste-map-20.0.5.tgz#abad74efb1a005974a7b6517e11010709cab9112"
   dependencies:
     fb-watchman "^2.0.0"
     graceful-fs "^4.1.11"
-    jest-docblock "^20.0.1"
+    jest-docblock "^20.0.3"
     micromatch "^2.3.11"
     sane "~1.6.0"
     worker-farm "^1.3.1"
 
-jest-jasmine2@^20.0.1:
-  version "20.0.1"
-  resolved "https://registry.yarnpkg.com/jest-jasmine2/-/jest-jasmine2-20.0.1.tgz#675772b1fd32ad74e92e8ae8282f8ea71d1de168"
+jest-jasmine2@^20.0.4:
+  version "20.0.4"
+  resolved "https://registry.yarnpkg.com/jest-jasmine2/-/jest-jasmine2-20.0.4.tgz#fcc5b1411780d911d042902ef1859e852e60d5e1"
   dependencies:
     chalk "^1.1.3"
     graceful-fs "^4.1.11"
-    jest-diff "^20.0.1"
-    jest-matcher-utils "^20.0.1"
-    jest-matchers "^20.0.1"
-    jest-message-util "^20.0.1"
-    jest-snapshot "^20.0.1"
+    jest-diff "^20.0.3"
+    jest-matcher-utils "^20.0.3"
+    jest-matchers "^20.0.3"
+    jest-message-util "^20.0.3"
+    jest-snapshot "^20.0.3"
     once "^1.4.0"
     p-map "^1.1.1"
 
-jest-matcher-utils@^20.0.1:
-  version "20.0.1"
-  resolved "https://registry.yarnpkg.com/jest-matcher-utils/-/jest-matcher-utils-20.0.1.tgz#31aef67f59535af3c2271a3a3685db604dbd1622"
+jest-matcher-utils@^20.0.3:
+  version "20.0.3"
+  resolved "https://registry.yarnpkg.com/jest-matcher-utils/-/jest-matcher-utils-20.0.3.tgz#b3a6b8e37ca577803b0832a98b164f44b7815612"
   dependencies:
     chalk "^1.1.3"
-    pretty-format "^20.0.1"
+    pretty-format "^20.0.3"
 
-jest-matchers@^20.0.1:
-  version "20.0.1"
-  resolved "https://registry.yarnpkg.com/jest-matchers/-/jest-matchers-20.0.1.tgz#053b7654ce60129268f39992886e987a5201bb90"
+jest-matchers@^20.0.3:
+  version "20.0.3"
+  resolved "https://registry.yarnpkg.com/jest-matchers/-/jest-matchers-20.0.3.tgz#ca69db1c32db5a6f707fa5e0401abb55700dfd60"
   dependencies:
-    jest-diff "^20.0.1"
-    jest-matcher-utils "^20.0.1"
-    jest-message-util "^20.0.1"
-    jest-regex-util "^20.0.1"
+    jest-diff "^20.0.3"
+    jest-matcher-utils "^20.0.3"
+    jest-message-util "^20.0.3"
+    jest-regex-util "^20.0.3"
 
-jest-message-util@^20.0.1:
-  version "20.0.1"
-  resolved "https://registry.yarnpkg.com/jest-message-util/-/jest-message-util-20.0.1.tgz#ac21cb055a6a5786b7f127ac7e705df5ffb1c335"
+jest-message-util@^20.0.3:
+  version "20.0.3"
+  resolved "https://registry.yarnpkg.com/jest-message-util/-/jest-message-util-20.0.3.tgz#6aec2844306fcb0e6e74d5796c1006d96fdd831c"
   dependencies:
     chalk "^1.1.3"
     micromatch "^2.3.11"
     slash "^1.0.0"
 
-jest-mock@^20.0.1:
-  version "20.0.1"
-  resolved "https://registry.yarnpkg.com/jest-mock/-/jest-mock-20.0.1.tgz#f4cca2e87e441b66fabe4ead6a6d61773ec0773a"
+jest-mock@^20.0.3:
+  version "20.0.3"
+  resolved "https://registry.yarnpkg.com/jest-mock/-/jest-mock-20.0.3.tgz#8bc070e90414aa155c11a8d64c869a0d5c71da59"
 
-jest-regex-util@^20.0.1:
-  version "20.0.1"
-  resolved "https://registry.yarnpkg.com/jest-regex-util/-/jest-regex-util-20.0.1.tgz#ecbcca8fbe4e217bca7f6f42a9b831d051224dc4"
+jest-regex-util@^20.0.3:
+  version "20.0.3"
+  resolved "https://registry.yarnpkg.com/jest-regex-util/-/jest-regex-util-20.0.3.tgz#85bbab5d133e44625b19faf8c6aa5122d085d762"
 
-jest-resolve-dependencies@^20.0.1:
-  version "20.0.1"
-  resolved "https://registry.yarnpkg.com/jest-resolve-dependencies/-/jest-resolve-dependencies-20.0.1.tgz#38fc012191775b0b277fabebb37aa8282e26846f"
+jest-resolve-dependencies@^20.0.3:
+  version "20.0.3"
+  resolved "https://registry.yarnpkg.com/jest-resolve-dependencies/-/jest-resolve-dependencies-20.0.3.tgz#6e14a7b717af0f2cb3667c549de40af017b1723a"
   dependencies:
-    jest-regex-util "^20.0.1"
+    jest-regex-util "^20.0.3"
 
-jest-resolve@^20.0.1:
-  version "20.0.1"
-  resolved "https://registry.yarnpkg.com/jest-resolve/-/jest-resolve-20.0.1.tgz#cace553663f25c703dc977a4ce176e29eda92772"
+jest-resolve@^20.0.4:
+  version "20.0.4"
+  resolved "https://registry.yarnpkg.com/jest-resolve/-/jest-resolve-20.0.4.tgz#9448b3e8b6bafc15479444c6499045b7ffe597a5"
   dependencies:
     browser-resolve "^1.11.2"
     is-builtin-module "^1.0.0"
     resolve "^1.3.2"
 
-jest-runtime@^20.0.1:
-  version "20.0.1"
-  resolved "https://registry.yarnpkg.com/jest-runtime/-/jest-runtime-20.0.1.tgz#384f9298b8e8a177870c6d9ad0023db10ddcaedc"
+jest-runtime@^20.0.4:
+  version "20.0.4"
+  resolved "https://registry.yarnpkg.com/jest-runtime/-/jest-runtime-20.0.4.tgz#a2c802219c4203f754df1404e490186169d124d8"
   dependencies:
     babel-core "^6.0.0"
-    babel-jest "^20.0.1"
+    babel-jest "^20.0.3"
     babel-plugin-istanbul "^4.0.0"
     chalk "^1.1.3"
     convert-source-map "^1.4.0"
     graceful-fs "^4.1.11"
-    jest-config "^20.0.1"
-    jest-haste-map "^20.0.1"
-    jest-regex-util "^20.0.1"
-    jest-resolve "^20.0.1"
-    jest-util "^20.0.1"
+    jest-config "^20.0.4"
+    jest-haste-map "^20.0.4"
+    jest-regex-util "^20.0.3"
+    jest-resolve "^20.0.4"
+    jest-util "^20.0.3"
     json-stable-stringify "^1.0.1"
     micromatch "^2.3.11"
     strip-bom "3.0.0"
     yargs "^7.0.2"
 
-jest-snapshot@^20.0.1:
-  version "20.0.1"
-  resolved "https://registry.yarnpkg.com/jest-snapshot/-/jest-snapshot-20.0.1.tgz#3704c599705042f20ec7c95ba76a4524c744dfac"
+jest-snapshot@^20.0.3:
+  version "20.0.3"
+  resolved "https://registry.yarnpkg.com/jest-snapshot/-/jest-snapshot-20.0.3.tgz#5b847e1adb1a4d90852a7f9f125086e187c76566"
   dependencies:
     chalk "^1.1.3"
-    jest-diff "^20.0.1"
-    jest-matcher-utils "^20.0.1"
-    jest-util "^20.0.1"
+    jest-diff "^20.0.3"
+    jest-matcher-utils "^20.0.3"
+    jest-util "^20.0.3"
     natural-compare "^1.4.0"
-    pretty-format "^20.0.1"
+    pretty-format "^20.0.3"
 
-jest-util@^20.0.1:
-  version "20.0.1"
-  resolved "https://registry.yarnpkg.com/jest-util/-/jest-util-20.0.1.tgz#a3e7afb67110b2c3ac77b82e9a51ca57f4ff72a1"
+jest-util@^20.0.3:
+  version "20.0.3"
+  resolved "https://registry.yarnpkg.com/jest-util/-/jest-util-20.0.3.tgz#0c07f7d80d82f4e5a67c6f8b9c3fe7f65cfd32ad"
   dependencies:
     chalk "^1.1.3"
     graceful-fs "^4.1.11"
-    jest-message-util "^20.0.1"
-    jest-mock "^20.0.1"
-    jest-validate "^20.0.1"
+    jest-message-util "^20.0.3"
+    jest-mock "^20.0.3"
+    jest-validate "^20.0.3"
     leven "^2.1.0"
     mkdirp "^0.5.1"
 
-jest-validate@^20.0.1:
-  version "20.0.1"
-  resolved "https://registry.yarnpkg.com/jest-validate/-/jest-validate-20.0.1.tgz#a236c29e3c29e9b92a1e5da211a732f0238da928"
+jest-validate@^20.0.3:
+  version "20.0.3"
+  resolved "https://registry.yarnpkg.com/jest-validate/-/jest-validate-20.0.3.tgz#d0cfd1de4f579f298484925c280f8f1d94ec3cab"
   dependencies:
     chalk "^1.1.3"
-    jest-matcher-utils "^20.0.1"
+    jest-matcher-utils "^20.0.3"
     leven "^2.1.0"
-    pretty-format "^20.0.1"
+    pretty-format "^20.0.3"
 
-jest@^20.0.1:
-  version "20.0.1"
-  resolved "https://registry.yarnpkg.com/jest/-/jest-20.0.1.tgz#4e268159ccc3b659966939de817c75bfe9e0157d"
+jest@^20.0.4:
+  version "20.0.4"
+  resolved "https://registry.yarnpkg.com/jest/-/jest-20.0.4.tgz#3dd260c2989d6dad678b1e9cc4d91944f6d602ac"
   dependencies:
-    jest-cli "^20.0.1"
+    jest-cli "^20.0.4"
 
 jodid25519@^1.0.0:
   version "1.0.2"
@@ -1936,6 +2135,10 @@ jsprim@^1.2.2:
     json-schema "0.2.3"
     verror "1.3.6"
 
+jsx-ast-utils@^1.4.0, jsx-ast-utils@^1.4.1:
+  version "1.4.1"
+  resolved "https://registry.yarnpkg.com/jsx-ast-utils/-/jsx-ast-utils-1.4.1.tgz#3867213e8dd79bf1e8f2300c0cfc1efb182c0df1"
+
 kind-of@^3.0.2:
   version "3.2.0"
   resolved "https://registry.yarnpkg.com/kind-of/-/kind-of-3.2.0.tgz#b58abe4d5c044ad33726a8c1525b48cf891bff07"
@@ -1973,12 +2176,25 @@ load-json-file@^1.0.0:
     pinkie-promise "^2.0.0"
     strip-bom "^2.0.0"
 
+load-json-file@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/load-json-file/-/load-json-file-2.0.0.tgz#7947e42149af80d696cbf797bcaabcfe1fe29ca8"
+  dependencies:
+    graceful-fs "^4.1.2"
+    parse-json "^2.2.0"
+    pify "^2.0.0"
+    strip-bom "^3.0.0"
+
 locate-path@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/locate-path/-/locate-path-2.0.0.tgz#2b568b265eec944c6d9c0de9c3dbbbca0354cd8e"
   dependencies:
     p-locate "^2.0.0"
     path-exists "^3.0.0"
+
+lodash.cond@^4.3.0:
+  version "4.5.2"
+  resolved "https://registry.yarnpkg.com/lodash.cond/-/lodash.cond-4.5.2.tgz#f471a1da486be60f6ab955d17115523dd1d255d5"
 
 lodash@^4.0.0, lodash@^4.14.0, lodash@^4.2.0, lodash@^4.3.0:
   version "4.17.4"
@@ -2056,6 +2272,10 @@ ms@0.7.3:
   version "0.7.3"
   resolved "https://registry.yarnpkg.com/ms/-/ms-0.7.3.tgz#708155a5e44e33f5fd0fc53e81d0d40a91be1fff"
 
+ms@2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/ms/-/ms-2.0.0.tgz#5608aeadfc00be6c2901df5f9861788de0d597c8"
+
 mute-stream@0.0.5:
   version "0.0.5"
   resolved "https://registry.yarnpkg.com/mute-stream/-/mute-stream-0.0.5.tgz#8fbfabb0a98a253d3184331f9e8deb7372fac6c0"
@@ -2107,6 +2327,10 @@ oauth-sign@~0.8.1:
 object-assign@^4.0.1, object-assign@^4.1.0:
   version "4.1.1"
   resolved "https://registry.yarnpkg.com/object-assign/-/object-assign-4.1.1.tgz#2109adc7965887cfc05cbbd442cac8bfbb360863"
+
+object-keys@^1.0.8:
+  version "1.0.11"
+  resolved "https://registry.yarnpkg.com/object-keys/-/object-keys-1.0.11.tgz#c54601778ad560f1142ce0e01bcca8b56d13426d"
 
 object.omit@^2.0.0:
   version "2.0.1"
@@ -2220,6 +2444,12 @@ path-type@^1.0.0:
     pify "^2.0.0"
     pinkie-promise "^2.0.0"
 
+path-type@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/path-type/-/path-type-2.0.0.tgz#f012ccb8415b7096fc2daa1054c3d72389594c73"
+  dependencies:
+    pify "^2.0.0"
+
 performance-now@^0.2.0:
   version "0.2.0"
   resolved "https://registry.yarnpkg.com/performance-now/-/performance-now-0.2.0.tgz#33ef30c5c77d4ea21c5a53869d91b56d8f2555e5"
@@ -2238,6 +2468,12 @@ pinkie@^2.0.0:
   version "2.0.4"
   resolved "https://registry.yarnpkg.com/pinkie/-/pinkie-2.0.4.tgz#72556b80cfa0d48a974e80e77248e80ed4f7f870"
 
+pkg-dir@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/pkg-dir/-/pkg-dir-1.0.0.tgz#7a4b508a8d5bb2d629d447056ff4e9c9314cf3d4"
+  dependencies:
+    find-up "^1.0.0"
+
 pluralize@^1.2.1:
   version "1.2.1"
   resolved "https://registry.yarnpkg.com/pluralize/-/pluralize-1.2.1.tgz#d1a21483fd22bb41e58a12fa3421823140897c45"
@@ -2250,9 +2486,9 @@ preserve@^0.2.0:
   version "0.2.0"
   resolved "https://registry.yarnpkg.com/preserve/-/preserve-0.2.0.tgz#815ed1f6ebc65926f865b310c0713bcb3315ce4b"
 
-pretty-format@^20.0.1:
-  version "20.0.1"
-  resolved "https://registry.yarnpkg.com/pretty-format/-/pretty-format-20.0.1.tgz#ba95329771907c189643dd251e244061ff642350"
+pretty-format@^20.0.3:
+  version "20.0.3"
+  resolved "https://registry.yarnpkg.com/pretty-format/-/pretty-format-20.0.3.tgz#020e350a560a1fe1a98dc3beb6ccffb386de8b14"
   dependencies:
     ansi-regex "^2.1.1"
     ansi-styles "^3.0.0"
@@ -2295,6 +2531,13 @@ read-pkg-up@^1.0.1:
     find-up "^1.0.0"
     read-pkg "^1.0.0"
 
+read-pkg-up@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/read-pkg-up/-/read-pkg-up-2.0.0.tgz#6b72a8048984e0c41e79510fd5e9fa99b3b549be"
+  dependencies:
+    find-up "^2.0.0"
+    read-pkg "^2.0.0"
+
 read-pkg@^1.0.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/read-pkg/-/read-pkg-1.1.0.tgz#f5ffaa5ecd29cb31c0474bca7d756b6bb29e3f28"
@@ -2302,6 +2545,14 @@ read-pkg@^1.0.0:
     load-json-file "^1.0.0"
     normalize-package-data "^2.3.2"
     path-type "^1.0.0"
+
+read-pkg@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/read-pkg/-/read-pkg-2.0.0.tgz#8ef1c0623c6a6db0dc6713c4bfac46332b2368f8"
+  dependencies:
+    load-json-file "^2.0.0"
+    normalize-package-data "^2.3.2"
+    path-type "^2.0.0"
 
 readable-stream@^2.2.2:
   version "2.2.9"
@@ -2438,7 +2689,7 @@ resolve@1.1.7:
   version "1.1.7"
   resolved "https://registry.yarnpkg.com/resolve/-/resolve-1.1.7.tgz#203114d82ad2c5ed9e8e0411b3932875e889e97b"
 
-resolve@^1.1.6, resolve@^1.3.2:
+resolve@^1.1.6, resolve@^1.2.0, resolve@^1.3.2:
   version "1.3.3"
   resolved "https://registry.yarnpkg.com/resolve/-/resolve-1.3.3.tgz#655907c3469a8680dc2de3a275a8fdd69691f0e5"
   dependencies:


### PR DESCRIPTION
This PR builds on work begun by @tejasbubane , who had the excellent idea that builds should run faster by invoking Jest once to run all tests.  

1. Builds on Travis now run the `test-travis` make task, which speeds up build times.  One potential disadvantage is that tests are not run sequentially, which can make debugging a challenge. 
2. Local build, run with `make test`, will still run the suite for each exercise sequentially, making debugging more straightforward.
3. `.babelrc` has been removed, as it's not needed.  Configuration is now in `package.json`.
4. Some dependencies have been updated.

This PR looks more extensive than it is, because every `package.json` file has been updated.  Really, the changes are in the main `package.json` file and the `Makefile`.