### PR TITLE
port proverb exercise from javascript track

### DIFF
--- a/config.json
+++ b/config.json
@@ -666,6 +666,21 @@
       ]
     },
     {
+      "uuid": "5626f5b6-207b-458b-92b6-eff2cadb240a",
+      "slug": "proverb",
+      "core": false,
+      "unlocked_by": "bob",
+      "difficulty": 4,
+      "topics": [
+        "Control flow (conditionals)",
+        "Control flow (loops)",
+        "Arrays",
+        "Strings",
+        "Text formatting",
+        "Optional values"
+      ]
+    },
+    {
       "uuid": "1a6c4a3b-d5db-4a5a-b123-66cf085defe6",
       "slug": "flatten-array",
       "core": false,

--- a/exercises/proverb/README.md
+++ b/exercises/proverb/README.md
@@ -1,0 +1,63 @@
+# Proverb
+
+"For want of a horseshoe nail, a kingdom was lost" is a popular proverb. There are may variations
+of this proverb and these variations can be chained together. For example:
+
+> For want of a nail the shoe was lost.  
+> For want of a shoe the horse was lost.  
+> For want of a horse the rider was lost.  
+> For want of a rider the message was lost.  
+> For want of a message the battle was lost.  
+> For want of a battle the kingdom was lost.  
+> And all for the want of a horseshoe nail.
+
+Given two or more nouns, construct the full chain of events for the above proverb.
+For example, given the nouns "nail", "shoe" and "horse", your program should output the text:
+
+>For want of a nail the shoe was lost.
+>For want of a shoe the horse was lost.
+>And all for the want of a nail.
+
+Given the nouns, "nail", "shoe", "horse", "rider", "message",  and a qualifier "horseshoe", your program should output:
+
+> For want of a nail the shoe was lost.  
+> For want of a shoe the horse was lost.  
+> For want of a horse the rider was lost.  
+> For want of a rider the message was lost. 
+> And all for the want of a horseshoe nail.
+
+
+## Setup
+
+Go through the setup instructions for EcmaScript to
+install the necessary dependencies:
+
+http://exercism.io/languages/ecmascript
+
+## Requirements
+
+Install assignment dependencies:
+
+```bash
+$ npm install
+```
+
+## Making the test suite pass
+
+Execute the tests with:
+
+```bash
+$ npm test
+```
+
+In the test suites all tests but the first have been skipped.
+
+Once you get a test passing, you can enable the next one by
+changing `xtest` to `test`.
+
+## Source
+
+Wikipedia [http://en.wikipedia.org/wiki/For_Want_of_a_Nail](http://en.wikipedia.org/wiki/For_Want_of_a_Nail)
+
+## Submitting Incomplete Solutions
+It's possible to submit an incomplete solution so you can see how others have completed the exercise.

--- a/exercises/proverb/example.js
+++ b/exercises/proverb/example.js
@@ -1,0 +1,23 @@
+const lastArgIsOptions = (args) => {
+  const last = args[args.length - 1];
+  return typeof last === 'object';
+};
+
+const conclusion = (firstArg, qualifier = '') => `And all for the want of a ${qualifier}${firstArg}.`;
+
+const proverb = (...args) => {
+  let options = {};
+  if (lastArgIsOptions(args)) {
+    options = args.pop();
+  }
+
+  const allExceptLastArg = args.slice(0, -1);
+  const chainOfEvents = allExceptLastArg.map((arg, index) => `For want of a ${arg} the ${args[index + 1]} was lost.`);
+
+  const qualifier = options.qualifier ? `${options.qualifier} ` : options.qualifier;
+  chainOfEvents.push(conclusion(args[0], qualifier));
+
+  return chainOfEvents.join('\n');
+};
+
+export default proverb;

--- a/exercises/proverb/package.json
+++ b/exercises/proverb/package.json
@@ -1,0 +1,69 @@
+{
+  "name": "xecmascript",
+  "version": "0.0.0",
+  "description": "Exercism exercises in ECMAScript 6.",
+  "author": "Katrina Owen",
+  "private": true,
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/exercism/xecmascript"
+  },
+  "devDependencies": {
+    "babel-jest": "^20.0.3",
+    "babel-plugin-transform-builtin-extend": "^1.1.2",
+    "babel-preset-env": "^1.4.0",
+    "eslint": "^3.19.0",
+    "eslint-config-airbnb": "^15.0.1",
+    "eslint-plugin-import": "^2.2.0",
+    "eslint-plugin-jsx-a11y": "^5.0.1",
+    "eslint-plugin-react": "^7.0.1",
+    "jest": "^20.0.4"
+  },
+  "jest": {
+    "modulePathIgnorePatterns": [
+      "package.json"
+    ]
+  },
+  "babel": {
+    "presets": [
+      "env"
+    ],
+    "plugins": [
+      [
+        "babel-plugin-transform-builtin-extend",
+        {
+          "globals": [
+            "Error"
+          ]
+        }
+      ],
+      ["transform-regenerator"]
+    ]
+},
+  "scripts": {
+    "test": "jest --no-cache ./*",
+    "watch": "jest --no-cache --watch ./*",
+    "lint": "eslint .",
+    "lint-test": "eslint . && jest --no-cache ./* "
+  },
+  "eslintConfig": {
+    "parserOptions": {
+      "ecmaVersion": 6,
+      "sourceType": "module"
+    },
+    "env": {
+      "es6": true,
+      "node": true,
+      "jest": true
+    },
+    "extends": "airbnb",
+    "rules": {
+      "import/no-unresolved": "off",
+      "import/extensions": "off"
+    }
+  },
+  "licenses": [
+    "MIT"
+  ],
+  "dependencies": {}
+}

--- a/exercises/proverb/proverb.spec.js
+++ b/exercises/proverb/proverb.spec.js
@@ -1,0 +1,70 @@
+import proverb from './proverb';
+
+describe('Proverb Test Suite', () => {
+  test('a single consequence', () => {
+    const result = proverb('nail', 'shoe');
+
+    expect(result).toEqual(
+      `For want of a nail the shoe was lost.
+And all for the want of a nail.`);
+  });
+
+  xtest('a short chain of consequences', () => {
+    const result = proverb('nail', 'shoe', 'horse');
+
+    expect(result).toEqual(
+      `For want of a nail the shoe was lost.
+For want of a shoe the horse was lost.
+And all for the want of a nail.`);
+  });
+
+  xtest('a longer chain of consequences', () => {
+    const result = proverb('nail', 'shoe', 'horse', 'rider');
+    expect(result).toEqual(
+      `For want of a nail the shoe was lost.
+For want of a shoe the horse was lost.
+For want of a horse the rider was lost.
+And all for the want of a nail.`);
+  });
+
+  xtest('proverb function does not hard code the rhyme dictionary', () => {
+    const result = proverb('key', 'value');
+
+    expect(result).toEqual(
+        `For want of a key the value was lost.
+And all for the want of a key.`);
+  });
+
+  xtest('the whole proveb', () => {
+    const result = proverb('nail', 'shoe', 'horse', 'rider',
+      'message', 'battle', 'kingdom');
+
+    expect(result).toEqual(
+      `For want of a nail the shoe was lost.
+For want of a shoe the horse was lost.
+For want of a horse the rider was lost.
+For want of a rider the message was lost.
+For want of a message the battle was lost.
+For want of a battle the kingdom was lost.
+And all for the want of a nail.`);
+  });
+
+  xtest('proverb is the same each time', () => {
+    expect(proverb('nail', 'shoe')).toEqual(proverb('nail', 'shoe'));
+  });
+
+  xtest('the use of an optional qualifier in the final consequence', () => {
+    const result = proverb('nail', 'shoe', 'horse', 'rider',
+        'message', 'battle', 'kingdom',
+        { qualifier: 'horseshoe' });
+
+    expect(result).toEqual(
+        `For want of a nail the shoe was lost.
+For want of a shoe the horse was lost.
+For want of a horse the rider was lost.
+For want of a rider the message was lost.
+For want of a message the battle was lost.
+For want of a battle the kingdom was lost.
+And all for the want of a horseshoe nail.`);
+  });
+});


### PR DESCRIPTION
Creating a new pull request with the code changes for this exercise.  I closed the old one because the git commit history for the branch associated with previous pull request did not look clean after the merge with master:

commit accd83f0e63d522f6ee1876637ed86cf952575cc
Merge: 242942b d1d8a82
Author: sabbas <syed.k.abbas1988@gmail.com>
Date:   Tue Aug 15 06:20:46 2017 -0500

    Merge branch 'master' into port-proverb-exercise-from-javascript

commit d1d8a82fcc0d3feec1734138778fb92a87230b4b
Author: Syed Abbas <syed.k.abbas1988@gmail.com>
Date:   Thu Aug 10 14:02:19 2017 -0500

    Add exercise run-length-encoding (#335)

commit 242942b035fedde096a92d296cf5988ff0ec2c15
Author: sabbas <syed.k.abbas1988@gmail.com>
Date:   Thu Aug 10 07:09:53 2017 -0500

    Port Proverb Exercise from JavaScript Track


This is probably because I created an empty pull request for the proverb exercises before the run-length-encoding pull request was merged into master:
