### PR TITLE
Queen attack: force test failure when exception is not thrown

### DIFF
--- a/exercises/queen-attack/example.js
+++ b/exercises/queen-attack/example.js
@@ -1,10 +1,34 @@
-const W = 8,
-  H = 8,
-  STARTING = { black: [7, 3], white: [0, 3] };
+const W = 8;
+const H = 8;
+const STARTING = { black: [7, 3], white: [0, 3] };
+
+function samePosition({ white, black }) {
+  return white[0] === black[0] && white[1] === black[1];
+}
+
+function buildRow(cell, colCount) {
+  return Array(...Array(colCount)).map(() => cell);
+}
+
+function concatRows(row, rowCount) {
+  return [...Array.prototype.concat.apply(buildRow(row, rowCount)).join('')];
+}
+
+function constructBoard() {
+  let row = buildRow('_ ', W).join('');
+  row = `${row.substring(0, row.length - 1)}\n`;
+  return concatRows(row, H);
+}
+
+function placePieces(self) {
+  const board = self.board;
+  board[(self.black[0] * W * 2) + (self.black[1] * 2)] = 'B';
+  board[(self.white[0] * W * 2) + (self.white[1] * 2)] = 'W';
+}
 
 const QueenAttack = (params = STARTING) => {
   const self = this instanceof QueenAttack ? this : Object.getPrototypeOf(QueenAttack);
-  if (params && params.white === params.black) {
+  if (samePosition(params)) {
     throw new Error('Queens cannot share the same space');
   }
 
@@ -24,24 +48,5 @@ const QueenAttack = (params = STARTING) => {
 
   return self;
 };
-
-function constructBoard() {
-  let row = buildRow('_ ', W).join('');
-  row = `${row.substring(0, row.length - 1)}\n`;
-  return concatRows(row, H);
-}
-
-function placePieces(self) {
-  self.board[self.black[0] * W * 2 + self.black[1] * 2] = 'B';
-  self.board[self.white[0] * W * 2 + self.white[1] * 2] = 'W';
-}
-
-function buildRow(cell, colCount) {
-  return Array(...Array(colCount)).map(() => cell);
-}
-
-function concatRows(row, rowCount) {
-  return [...Array.prototype.concat.apply(buildRow(row, rowCount)).join('')];
-}
 
 export default QueenAttack;

--- a/exercises/queen-attack/queen-attack.spec.js
+++ b/exercises/queen-attack/queen-attack.spec.js
@@ -15,26 +15,21 @@ describe('Queens', () => {
 
   xtest('cannot occupy the same space', () => {
     const positioning = { white: [2, 4], black: [2, 4] };
-
-    try {
-      new Queens(positioning);
-    } catch (error) {
-      expect(error).toEqual('Queens cannot share the same space');
-    }
+    const expectedError = 'Queens cannot share the same space';
+    expect(() => new Queens(positioning)).toThrow(expectedError);
   });
 
   xtest('toString representation', () => {
     const positioning = { white: [2, 4], black: [6, 6] };
     const queens = new Queens(positioning);
-    const board = '_ _ _ _ _ _ _ _\n\
-_ _ _ _ _ _ _ _\n\
-_ _ _ _ W _ _ _\n\
-_ _ _ _ _ _ _ _\n\
-_ _ _ _ _ _ _ _\n\
-_ _ _ _ _ _ _ _\n\
-_ _ _ _ _ _ B _\n\
-_ _ _ _ _ _ _ _\n\
-';
+    const board = ['_ _ _ _ _ _ _ _',
+      '_ _ _ _ _ _ _ _',
+      '_ _ _ _ W _ _ _',
+      '_ _ _ _ _ _ _ _',
+      '_ _ _ _ _ _ _ _',
+      '_ _ _ _ _ _ _ _',
+      '_ _ _ _ _ _ B _',
+      '_ _ _ _ _ _ _ _\n'].join('\n');
     expect(queens.toString()).toEqual(board);
   });
 


### PR DESCRIPTION
I noticed that this test will pass as long as the `Queens` constructor is implemented, because the assertion is in the catch. Since it was a quick fix, I didn't make an issue.