### PR TITLE
Synchronizing EcmaScript <-> Javascript test for simple-cipher

### DIFF
--- a/exercises/simple-cipher/simple-cipher.spec.js
+++ b/exercises/simple-cipher/simple-cipher.spec.js
@@ -76,4 +76,9 @@ describe('Substitution cipher', () => {
   xtest('can wrap on decode', () => {
     expect(cipher.decode('zabcdefghi')).toEqual('zzzzzzzzzz');
   });
+
+  xtest('can handle messages longer than the key', function() {
+    expect(new Cipher('abc').encode('iamapandabear'))
+      .toEqual('iboaqcnecbfcr');
+  });
 });


### PR DESCRIPTION
The test case was changed in both tracks with unrelated changes. This commit merges the two logically:
#347 
https://github.com/exercism/javascript/pull/401

The according sync-PR in JavaScript track:
https://github.com/exercism/javascript/pull/403