### PR TITLE
Fix link and remove incorrect version

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ Exercism exercises in ECMAScript 6
 ## Running the Unit Test Suite
 
 [Node.js](https://nodejs.org) must be installed. Follow these [instructions](http://exercism.io/languages/ecmascript/installation) for installing nodejs.
-We recommend using the LTS version.
+We recommend using the latest LTS version.
 
 Use `npm` to install all required dependencies:
 

--- a/README.md
+++ b/README.md
@@ -7,8 +7,8 @@ Exercism exercises in ECMAScript 6
 
 ## Running the Unit Test Suite
 
-[Node.js](https://nodejs.org) must be installed. Follow [these instructions](http://exercism.io/languages/ecmascript/installing) for installing nodejs.
-We recommend using the latest stable version (v7 at the moment).
+[Node.js](https://nodejs.org) must be installed. Follow these [instructions](http://exercism.io/languages/ecmascript/installation) for installing nodejs.
+We recommend using the LTS version.
 
 Use `npm` to install all required dependencies:
 


### PR DESCRIPTION
Node LTS is currently 6.11 but stating a version number here will become outdated so I think recommending the latest LTS is safer