### PR TITLE
Update makefile to check package.json on CI

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -17,11 +17,6 @@ TSTFILE := "$(subst _,-,$(ASSIGNMENT)).spec.$(FILEEXT)"
 SOURCE_PKG_MD5 ?= "`./bin/md5-hash ./package.json`"
 PKG_FILES= $(shell find ./exercises/*/* -maxdepth 1 -name package.json)
 
-test-package-files:
-	@for pkg in $(PKG_FILES); do \
-		! ./bin/md5-hash $$pkg | grep -qv $(SOURCE_PKG_MD5) || { echo "$$pkg does not match main package.json"; exit 1; }; \
-	done
-
 copy-assignment:
 	@cp package.json exercises/$(ASSIGNMENT)
 	@mkdir -p $(OUTDIR)
@@ -37,6 +32,10 @@ test-assignment:
 	@rm -rf $(OUTDIR)
 
 test-travis:
+	@echo "Checking that exercise package.json files match main package.json..."
+	@for pkg in $(PKG_FILES); do \
+  		! ./bin/md5-hash $$pkg | grep -qv $(SOURCE_PKG_MD5) || { echo "$$pkg does not match main package.json.  Please run 'make test' locally and commit the results."; exit 1; }; \
+  	done
 	@echo "Preparing tests..."
 	@for assignment in $(ASSIGNMENTS); do ASSIGNMENT=$$assignment $(MAKE) -s copy-assignment || exit 1; done
 	@node_modules/.bin/jest --bail $(OUTDIR)

--- a/README.md
+++ b/README.md
@@ -25,7 +25,8 @@ and suggesting changes that conform to best practices.
 The make script will test all exercises:
 
     make test
-
+    
+Note: `make test` is recommended BEFORE submitting a PR.  It will test your submission, and help guard against unintentional, unrelated changes.
 #### Test Specific Assignment
 Pass the exercise name to make script to run the tests for a specific exercise:
 

--- a/exercises/change/package.json
+++ b/exercises/change/package.json
@@ -9,7 +9,7 @@
     "url": "https://github.com/exercism/xecmascript"
   },
   "devDependencies": {
-    "babel-jest": "^20.0.3",
+    "babel-jest": "^21.2.0",
     "babel-plugin-transform-builtin-extend": "^1.1.2",
     "babel-preset-env": "^1.4.0",
     "eslint": "^3.19.0",
@@ -17,7 +17,7 @@
     "eslint-plugin-import": "^2.2.0",
     "eslint-plugin-jsx-a11y": "^5.0.1",
     "eslint-plugin-react": "^7.0.1",
-    "jest": "^20.0.4"
+    "jest": "^21.2.1"
   },
   "jest": {
     "modulePathIgnorePatterns": [
@@ -37,7 +37,9 @@
           ]
         }
       ],
-      ["transform-regenerator"]
+      [
+        "transform-regenerator"
+      ]
     ]
   },
   "scripts": {

--- a/exercises/protein-translation/package.json
+++ b/exercises/protein-translation/package.json
@@ -9,7 +9,7 @@
     "url": "https://github.com/exercism/xecmascript"
   },
   "devDependencies": {
-    "babel-jest": "^20.0.3",
+    "babel-jest": "^21.2.0",
     "babel-plugin-transform-builtin-extend": "^1.1.2",
     "babel-preset-env": "^1.4.0",
     "eslint": "^3.19.0",
@@ -17,7 +17,7 @@
     "eslint-plugin-import": "^2.2.0",
     "eslint-plugin-jsx-a11y": "^5.0.1",
     "eslint-plugin-react": "^7.0.1",
-    "jest": "^20.0.4"
+    "jest": "^21.2.1"
   },
   "jest": {
     "modulePathIgnorePatterns": [

--- a/exercises/rectangles/package.json
+++ b/exercises/rectangles/package.json
@@ -61,8 +61,7 @@
     "extends": "airbnb",
     "rules": {
       "import/no-unresolved": "off",
-      "import/extensions": "off",
-      "no-plusplus": "off"
+      "import/extensions": "off"
     }
   },
   "licenses": [

--- a/exercises/rotational-cipher/package.json
+++ b/exercises/rotational-cipher/package.json
@@ -61,8 +61,7 @@
     "extends": "airbnb",
     "rules": {
       "import/no-unresolved": "off",
-      "import/extensions": "off",
-      "no-plusplus": "off"
+      "import/extensions": "off"
     }
   },
   "licenses": [

--- a/exercises/spiral-matrix/package.json
+++ b/exercises/spiral-matrix/package.json
@@ -61,8 +61,7 @@
     "extends": "airbnb",
     "rules": {
       "import/no-unresolved": "off",
-      "import/extensions": "off",
-      "no-plusplus": "off"
+      "import/extensions": "off"
     }
   },
   "licenses": [

--- a/exercises/transpose/package.json
+++ b/exercises/transpose/package.json
@@ -9,7 +9,7 @@
     "url": "https://github.com/exercism/xecmascript"
   },
   "devDependencies": {
-    "babel-jest": "^20.0.3",
+    "babel-jest": "^21.2.0",
     "babel-plugin-transform-builtin-extend": "^1.1.2",
     "babel-preset-env": "^1.4.0",
     "eslint": "^3.19.0",
@@ -17,7 +17,7 @@
     "eslint-plugin-import": "^2.2.0",
     "eslint-plugin-jsx-a11y": "^5.0.1",
     "eslint-plugin-react": "^7.0.1",
-    "jest": "^20.0.4"
+    "jest": "^21.2.1"
   },
   "jest": {
     "modulePathIgnorePatterns": [


### PR DESCRIPTION
Closes #303 

Updates Makefile for CI, so that all exercise `package.json` files are checked against the main `package.json` file.  If they are not identical, the build fails.

NB: since the `copy-assignment` task _already_ copies the main `package.json` to a given exercise, and the contributors are meant to run `make test`, all files _should_ be updated before submission, so I did not make a separate task just to copy the `package.json` files as was discussed in #303.

Bonus: Looks like we had many exercises that did not have matching `package.json` files.  This caused the build to fail at first, so I guess the script is working...