### PR TITLE
Simple Cipher: Add tests for random key generation, 100+ character length

### DIFF
--- a/exercises/simple-cipher/simple-cipher.spec.js
+++ b/exercises/simple-cipher/simple-cipher.spec.js
@@ -1,10 +1,24 @@
 import Cipher from './simple-cipher';
 
+describe('Random key generation', () => {
+  xtest('generates keys at random', () => {
+    // Strictly speaking, this is difficult to test with 100% certainty.
+    // But, if you have a generator that generates 100-character-long
+    // strings of lowercase letters at random, the odds of two consecutively
+    // generated keys being identical are astronomically low.
+    expect(new Cipher().key).not.toEqual(new Cipher().key);
+  });
+});
+
 describe('Random key cipher', () => {
   const cipher = new Cipher();
 
   test('has a key made of letters', () => {
     expect(cipher.key).toMatch(/^[a-z]+$/);
+  });
+
+  xtest('has a key that is at least 100 characters long', () => {
+    expect(cipher.key.length).toBeGreaterThanOrEqual(100);
   });
 
   // Here we take advantage of the fact that plaintext of "aaa..."


### PR DESCRIPTION
_NB: I've made this same PR in the JavaScript track (https://github.com/exercism/javascript/pull/538) and TypeScript track (https://github.com/exercism/typescript/pull/186) and I'm making the rounds. I'd love to see this consistent across all the JS tracks!_

The README for this exercise describes generating random keys consisting of 100+ lowercase letters, but the only constraint enforced by the tests is that it must contain only lowercase letters. One could pass this constraint by simply defaulting the key to a hard-coded string like `lolnotrandom`.

This PR adds tests to enforce that keys are randomly generated (at least a simple test that if you generate 2 keys back to back, they are not the same key), and that they are at least 100 characters long.