### PR TITLE
Use npm-ci instead of npm-install

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,8 +3,10 @@ language: node_js
 node_js:
 - 'node'
 sudo: false
+before_install:
+- npm i -g npm@latest
 install:
-- npm install --no-save
+- npm ci
 script:
 - bin/fetch-configlet
 - bin/configlet lint .


### PR DESCRIPTION
Looks like `npm-ci` is meant to be used in CI environments.
https://docs.npmjs.com/cli/ci

Also we don't need the `--no-save` flag with this.