### PR TITLE
robot-simulator: fix test that didn't fail if nothing was thrown

### DIFF
--- a/exercises/robot-simulator/example.js
+++ b/exercises/robot-simulator/example.js
@@ -1,3 +1,10 @@
+export class InvalidInputError extends Error {
+  constructor(message) {
+    super();
+    this.message = message || 'Invalid Input';
+  }
+}
+
 class Robot {
   constructor() {
     this.coordinates = [0, 0];
@@ -11,7 +18,7 @@ class Robot {
   orient(direction) {
     const validDirections = ['north', 'south', 'east', 'west'];
     if (!validDirections.includes(direction)) {
-      throw 'Invalid Robot Bearing';
+      throw new InvalidInputError('Invalid Robot Bearing');
     }
 
     this.bearing = direction;

--- a/exercises/robot-simulator/example.js
+++ b/exercises/robot-simulator/example.js
@@ -9,6 +9,11 @@ class Robot {
   }
 
   orient(direction) {
+    const validDirections = ['north', 'south', 'east', 'west'];
+    if (!validDirections.includes(direction)) {
+      throw 'Invalid Robot Bearing';
+    }
+
     this.bearing = direction;
     return `The robot is pointed ${direction}`;
   }

--- a/exercises/robot-simulator/robot-simulator.spec.js
+++ b/exercises/robot-simulator/robot-simulator.spec.js
@@ -13,11 +13,7 @@ describe('Robot', () => {
   });
 
   xtest('invalid robot bearing', () => {
-    try {
-      robot.orient('crood');
-    } catch (exception) {
-      expect(exception).toEqual('Invalid Robot Bearing');
-    }
+    expect(() => robot.orient('crood')).toThrow('Invalid Robot Bearing');
   });
 
   xtest('turn right from north', () => {

--- a/exercises/robot-simulator/robot-simulator.spec.js
+++ b/exercises/robot-simulator/robot-simulator.spec.js
@@ -4,7 +4,7 @@ import { InvalidInputError } from './robot-simulator';
 describe('Robot', () => {
   const robot = new Robot();
 
-  xtest('robot bearing', () => {
+  test('robot bearing', () => {
     const directions = ['east', 'west', 'north', 'south'];
 
     directions.forEach((currentDirection) => {

--- a/exercises/robot-simulator/robot-simulator.spec.js
+++ b/exercises/robot-simulator/robot-simulator.spec.js
@@ -1,9 +1,10 @@
 import Robot from './robot-simulator';
+import { InvalidInputError } from './robot-simulator';
 
 describe('Robot', () => {
   const robot = new Robot();
 
-  test('robot bearing', () => {
+  xtest('robot bearing', () => {
     const directions = ['east', 'west', 'north', 'south'];
 
     directions.forEach((currentDirection) => {
@@ -13,7 +14,8 @@ describe('Robot', () => {
   });
 
   xtest('invalid robot bearing', () => {
-    expect(() => robot.orient('crood')).toThrow('Invalid Robot Bearing');
+    expect(InvalidInputError.prototype).toBeInstanceOf(Error);
+    expect(() => robot.orient('crood')).toThrow(InvalidInputError);
   });
 
   xtest('turn right from north', () => {


### PR DESCRIPTION
Solves #407:

The robot-simulator exercise includes a test that should fail if in case of an invalid argument
- no error message is thrown
- a wrong message is thrown

In fact, the test only fails in the latter case. So I fixed that. I didn't touch anything else but I really wonder why anybody would throw a String instead of an Error object.