### PR TITLE
add additional test to linked-list delete

### DIFF
--- a/exercises/linked-list/linked-list.spec.js
+++ b/exercises/linked-list/linked-list.spec.js
@@ -82,6 +82,22 @@ describe('LinkedList', () => {
     list.delete(10);
     expect(list.count()).toBe(0);
   });
+  xtest('deletes the first of two elements', () => {
+    const list = new LinkedList();
+    list.push(10);
+    list.push(20);
+    list.delete(10);
+    expect(list.count()).toBe(1);
+    expect(list.pop()).toBe(20);
+  });
+  xtest('deletes the second of two elements', () => {
+    const list = new LinkedList();
+    list.push(10);
+    list.push(20);
+    list.delete(20);
+    expect(list.count()).toBe(1);
+    expect(list.pop()).toBe(10);
+  });
   xtest('delete does not modify the list if the element is not found', () => {
     const list = new LinkedList();
     list.push(10);


### PR DESCRIPTION
I've observed it common for otherwise passing code to fail the case of deleting one of two remaining nodes.