### PR TITLE
Fix word-search test

### DIFF
--- a/exercises/word-search/word-search.spec.js
+++ b/exercises/word-search/word-search.spec.js
@@ -240,7 +240,7 @@ describe('multi line grids', () => {
 describe('can find multiple words', () => {
   xtest('can find two words written left to right', () => {
     const grid = [
-      "jefblpepre",
+      "aefblpepre",
       "camdcimgtc",
       "oivokprjsm",
       "pbwasqroua",


### PR DESCRIPTION
The problem is that the grid contents two `java` words but it should have just one.

The first one is: `{ start: [1, 1], end: [4, 4] }`
The second one is: `{ start: [11, 2], end: [11, 5] }`

```javascript
const grid = [
  "jefblpepre",
  "camdcimgtc",
  "oivokprjsm",
  "pbwasqroua",
  "rixilelhrs",
  "wolcqlirpc",
  "screeaumgr",
  "alxhpburyi",
  "jalaycalmp",
  "clojurermt",
  "xjavamtzlp"
];
```

The test fails if your implement finds the first `java` first.