### PR TITLE
Port reverse-string from javascript track

### DIFF
--- a/config.json
+++ b/config.json
@@ -31,6 +31,18 @@
       ]
     },
     {
+      "slug": "reverse-string",
+      "uuid": "553a6be7-eecb-45dc-9cea-05126c525f1b",
+      "core": false,
+      "unlocked_by": "leap",
+      "difficulty": 2,
+      "topics": [
+        "for",
+        "loops",
+        "strings"
+      ]
+    },
+    {
       "slug": "rna-transcription",
       "uuid": "342974d6-9083-4754-a6c5-ed1e19e40ec5",
       "core": true,

--- a/config.json
+++ b/config.json
@@ -32,7 +32,7 @@
     },
     {
       "slug": "reverse-string",
-      "uuid": "553a6be7-eecb-45dc-9cea-05126c525f1b",
+      "uuid": "e84c97eb-dbec-487c-b99f-ae9924e16293",
       "core": false,
       "unlocked_by": "leap",
       "difficulty": 2,

--- a/exercises/reverse-string/README.md
+++ b/exercises/reverse-string/README.md
@@ -1,0 +1,40 @@
+# Reverse String
+
+Reverse a string
+
+For example:
+input: "cool"
+output: "looc"
+
+## Setup
+
+Go through the setup instructions for JavaScript to install the
+ necessary dependencies:
+
+http://exercism.io/languages/javascript/installation
+
+## Running the test suite
+
+The provided test suite uses [Jasmine](https://jasmine.github.io/).
+You can install it by opening a terminal window and running the
+following command:
+
+```sh
+npm install -g jasmine
+```
+
+Run the test suite from the exercise directory with:
+
+```sh
+jasmine reverse-string.spec.js
+```
+
+In many test suites all but the first test have been marked "pending".
+Once you get a test passing, activate the next one by changing `xit` to `it`.
+
+## Source
+
+Introductory challenge to reverse an input string [https://medium.freecodecamp.org/how-to-reverse-a-string-in-javascript-in-3-different-ways-75e4763c68cb](https://medium.freecodecamp.org/how-to-reverse-a-string-in-javascript-in-3-different-ways-75e4763c68cb)
+
+## Submitting Incomplete Solutions
+It's possible to submit an incomplete solution so you can see how others have completed the exercise.

--- a/exercises/reverse-string/README.md
+++ b/exercises/reverse-string/README.md
@@ -8,29 +8,31 @@ output: "looc"
 
 ## Setup
 
-Go through the setup instructions for JavaScript to install the
- necessary dependencies:
+Go through the setup instructions for ECMAScript to
+install the necessary dependencies:
 
-http://exercism.io/languages/javascript/installation
+http://exercism.io/languages/ecmascript
 
-## Running the test suite
+## Requirements
 
-The provided test suite uses [Jasmine](https://jasmine.github.io/).
-You can install it by opening a terminal window and running the
-following command:
+Install assignment dependencies:
 
-```sh
-npm install -g jasmine
+```bash
+$ npm install
 ```
 
-Run the test suite from the exercise directory with:
+## Making the test suite pass
 
-```sh
-jasmine reverse-string.spec.js
+Execute the tests with:
+
+```bash
+$ npm test
 ```
 
-In many test suites all but the first test have been marked "pending".
-Once you get a test passing, activate the next one by changing `xit` to `it`.
+In the test suites all tests but the first have been skipped.
+
+Once you get a test passing, you can enable the next one by
+changing `xtest` to `test`.
 
 ## Source
 

--- a/exercises/reverse-string/example.js
+++ b/exercises/reverse-string/example.js
@@ -1,0 +1,9 @@
+function reverseString(string) {
+  let revString = '';
+  for (let i = string.length - 1; i >= 0; i -= 1) {
+    revString += string[i];
+  }
+  return revString;
+}
+
+export default reverseString;

--- a/exercises/reverse-string/package.json
+++ b/exercises/reverse-string/package.json
@@ -1,0 +1,70 @@
+{
+  "name": "xecmascript",
+  "version": "0.0.0",
+  "description": "Exercism exercises in ECMAScript 6.",
+  "author": "Katrina Owen",
+  "private": true,
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/exercism/xecmascript"
+  },
+  "devDependencies": {
+    "babel-jest": "^21.2.0",
+    "babel-plugin-transform-builtin-extend": "^1.1.2",
+    "babel-preset-env": "^1.4.0",
+    "eslint": "^3.19.0",
+    "eslint-config-airbnb": "^15.0.1",
+    "eslint-plugin-import": "^2.2.0",
+    "eslint-plugin-jsx-a11y": "^5.0.1",
+    "eslint-plugin-react": "^7.0.1",
+    "jest": "^21.2.1"
+  },
+  "jest": {
+    "modulePathIgnorePatterns": [
+      "package.json"
+    ]
+  },
+  "babel": {
+    "presets": [["env",{"targets":[{"node": "current"}]}]
+    ],
+    "plugins": [
+      [
+        "babel-plugin-transform-builtin-extend",
+        {
+          "globals": [
+            "Error"
+          ]
+        }
+      ],
+      [
+        "transform-regenerator"
+      ]
+    ]
+  },
+  "scripts": {
+    "test": "jest --no-cache ./*",
+    "watch": "jest --no-cache --watch ./*",
+    "lint": "eslint .",
+    "lint-test": "eslint . && jest --no-cache ./* "
+  },
+  "eslintConfig": {
+    "parserOptions": {
+      "ecmaVersion": 6,
+      "sourceType": "module"
+    },
+    "env": {
+      "es6": true,
+      "node": true,
+      "jest": true
+    },
+    "extends": "airbnb",
+    "rules": {
+      "import/no-unresolved": "off",
+      "import/extensions": "off"
+    }
+  },
+  "licenses": [
+    "MIT"
+  ],
+  "dependencies": {}
+}

--- a/exercises/reverse-string/reverse-string.spec.js
+++ b/exercises/reverse-string/reverse-string.spec.js
@@ -1,0 +1,33 @@
+import reverseString from './reverse-string';
+
+describe('ReverseString', () => {
+  test('empty string', () => {
+    const expected = '';
+    const actual = reverseString('');
+    expect(actual).toEqual(expected);
+  });
+
+  xtest('a word', () => {
+    const expected = 'tobor';
+    const actual = reverseString('robot');
+    expect(actual).toEqual(expected);
+  });
+
+  xtest('a capitalized word', () => {
+    const expected = 'nemaR';
+    const actual = reverseString('Ramen');
+    expect(actual).toEqual(expected);
+  });
+
+  xtest('a sentence with punctuation', () => {
+    const expected = '!yrgnuh ma I';
+    const actual = reverseString('I am hungry!');
+    expect(actual).toEqual(expected);
+  });
+
+  xtest('a palindrome', () => {
+    const expected = 'racecar';
+    const actual = reverseString('racecar');
+    expect(actual).toEqual(expected);
+  });
+});


### PR DESCRIPTION
A port of the JS 'reverse-string' challenge as requested in #417 

Things I did to port:
- Converted `it` to `test`
- Added exercise to config.json and change its UUID
- Updated tests and example to match new linter
- Copy ecmascript `setup`,`requirements` and `making the test suite pass` sections into exercise README.md
