### PR TITLE
Deprecate binary, trinary, octal and hexadecimal

### DIFF
--- a/config.json
+++ b/config.json
@@ -170,7 +170,8 @@
         "mathematics",
         "regular_expressions",
         "strings"
-      ]
+      ],
+      "deprecated": true
     },
     {
       "slug": "prime-factors",
@@ -688,7 +689,8 @@
         "mathematics",
         "regular_expressions",
         "strings"
-      ]
+      ],
+      "deprecated": true
     },
     {
       "slug": "sieve",
@@ -717,7 +719,8 @@
         "mathematics",
         "regular_expressions",
         "strings"
-      ]
+      ],
+      "deprecated": true
     },
     {
       "slug": "luhn",
@@ -827,7 +830,8 @@
         "mathematics",
         "regular_expressions",
         "strings"
-      ]
+      ],
+      "deprecated": true
     },
     {
       "slug": "largest-series-product",
@@ -1122,7 +1126,7 @@
       "slug": "all-your-base",
       "uuid": "d2d3cd13-b06c-4c24-9964-fb1554f70dd4",
       "core": false,
-      "unlocked_by": "binary",
+      "unlocked_by": null,
       "difficulty": 5,
       "topics": [
         "control_flow_conditionals",


### PR DESCRIPTION
In favour of `all-your-base`. Ref: https://github.com/exercism/problem-specifications/issues/279

We did this in https://github.com/exercism/ecmascript/pull/250 and was later reformatted in https://github.com/exercism/ecmascript/pull/321/files. I guess later while adding topics, the deprecated key was removed.

I have also removed `unlocked-by: binary` for `all-your-base` - since `binary` is deprecated now.