### PR TITLE
Adds empty RNA sequence spec

### DIFF
--- a/exercises/rna-transcription/rna-transcription.spec.js
+++ b/exercises/rna-transcription/rna-transcription.spec.js
@@ -3,7 +3,11 @@ import Transcriptor from './rna-transcription';
 describe('Transcriptor', () => {
   const transcriptor = new Transcriptor();
 
-  test('transcribes cytosine to guanine', () => {
+  test('empty rna sequence', () => {
+    expect(transcriptor.toRna('')).toEqual('');
+  });
+
+  xtest('transcribes cytosine to guanine', () => {
     expect(transcriptor.toRna('C')).toEqual('G');
   });
 


### PR DESCRIPTION
This PR adds a new spec for an empty rna sequence, which was just added to the `canonical-data.json` the other day.

https://github.com/exercism/problem-specifications/blob/master/exercises/rna-transcription/canonical-data.json