### PR TITLE
Fix unit tests for Collatz Conjecture exercise in accordance with issue #436:

### DIFF
--- a/exercises/collatz-conjecture/collatz-conjecture.spec.js
+++ b/exercises/collatz-conjecture/collatz-conjecture.spec.js
@@ -1,4 +1,4 @@
-import steps from './collatz-conjecture';
+import { steps } from './collatz-conjecture';
 
 describe('steps()', () => {
   test('zero steps for one', () => {

--- a/exercises/collatz-conjecture/example.js
+++ b/exercises/collatz-conjecture/example.js
@@ -1,4 +1,4 @@
-export default (n) => {
+export const steps = (n) => {
   if (n <= 0) {
     throw new Error('Only positive numbers are allowed');
   }


### PR DESCRIPTION
- Change default import `steps` to named import `{ steps }`.
- Change export statement of example.js from `export default (n) => {` to `export const steps = (n) => {`.