### PR TITLE
Fix unit tests for Armstrong Number exercise in accordance with issue #436:

### DIFF
--- a/exercises/armstrong-numbers/armstrong-numbers.spec.js
+++ b/exercises/armstrong-numbers/armstrong-numbers.spec.js
@@ -1,43 +1,43 @@
-import ArmstrongNumber from './armstrong-numbers';
+import { validate } from './armstrong-numbers';
 
 describe('ArmstrongNumber', () => {
   test('Single digit numbers are Armstrong numbers', () => {
     const input = 5;
-    expect(ArmstrongNumber.validate(input)).toBe(true);
+    expect(validate(input)).toBe(true);
   });
 
   xtest('There are no 2 digit Armstrong numbers', () => {
     const input = 10;
-    expect(ArmstrongNumber.validate(input)).toBe(false);
+    expect(validate(input)).toBe(false);
   });
 
   xtest('Three digit number that is an Armstrong number', () => {
     const input = 153;
-    expect(ArmstrongNumber.validate(input)).toBe(true);
+    expect(validate(input)).toBe(true);
   });
 
   xtest('Three digit number that is not an Armstrong number', () => {
     const input = 100;
-    expect(ArmstrongNumber.validate(input)).toBe(false);
+    expect(validate(input)).toBe(false);
   });
 
   xtest('Four digit number that is an Armstrong number', () => {
     const input = 9474;
-    expect(ArmstrongNumber.validate(input)).toBe(true);
+    expect(validate(input)).toBe(true);
   });
 
   xtest('Four digit number that is not an Armstrong number', () => {
     const input = 9475;
-    expect(ArmstrongNumber.validate(input)).toBe(false);
+    expect(validate(input)).toBe(false);
   });
 
   xtest('Seven digit number that is an Armstrong number', () => {
     const input = 9926315;
-    expect(ArmstrongNumber.validate(input)).toBe(true);
+    expect(validate(input)).toBe(true);
   });
 
   xtest('Seven digit number that is not an Armstrong number', () => {
     const input = 9926314;
-    expect(ArmstrongNumber.validate(input)).toBe(false);
+    expect(validate(input)).toBe(false);
   });
 });

--- a/exercises/armstrong-numbers/example.js
+++ b/exercises/armstrong-numbers/example.js
@@ -1,11 +1,7 @@
-const validate = input => {
+export const validate = (input) => {
   const digits = [...String(input)];
   const sum = digits.reduce((total, current) => (
     total + Math.pow(current, digits.length)
   ), 0);
   return sum === input;
-}
-
-export default {
-  validate,
-}
+};


### PR DESCRIPTION
- Change default import `ArmstrongNumbers` to named import `{ validate }`.
- Change calls to imported function from `ArmstrongNumbers.validate(input)` to the simpler `validate(input)`.
- Remove default export statement from example.js.
- Change export statement in example.js to a named export.