### PR TITLE
Fix unit tests for Accumulate exercise

### DIFF
--- a/exercises/accumulate/accumulate.spec.js
+++ b/exercises/accumulate/accumulate.spec.js
@@ -1,4 +1,4 @@
-import accumulate from './accumulate';
+import { accumulate } from './accumulate';
 
 describe('accumulate()', () => {
   test('accumulation empty', () => {

--- a/exercises/accumulate/example.js
+++ b/exercises/accumulate/example.js
@@ -1,4 +1,4 @@
-export default (list, accumulator) => {
+export const accumulate = (list, accumulator) => {
   const out = [];
   let idx = -1;
   const end = Array.isArray(list) ? list.length : 0;
@@ -9,4 +9,3 @@ export default (list, accumulator) => {
 
   return out;
 };
-


### PR DESCRIPTION
As per issue #436:
- Change default import `accumulate` to named import `{ accumulate }`.
- Change export statement of example.js from a default to a named export.