### PR TITLE
Fix unit tests for Alphametics exercise

### DIFF
--- a/exercises/alphametics/alphametics.spec.js
+++ b/exercises/alphametics/alphametics.spec.js
@@ -1,4 +1,4 @@
-import solve from './alphametics';
+import { solve } from './alphametics';
 
 describe('Solve the alphametics puzzle', () => {
   test('puzzle with three letters', () => {

--- a/exercises/alphametics/example.js
+++ b/exercises/alphametics/example.js
@@ -1,4 +1,4 @@
-export default function solve(puzzle) {
+export function solve(puzzle) {
   const parts = puzzle
     .split(/[+|==]/g)
     .map(o => o.trim())


### PR DESCRIPTION
As per issue #436:
- Change default import `solve` to named import `{ solve }`.
- Change export statement of example.js from a default to a named export.