### PR TITLE
Fix unit tests for Atbash Cipher exercise

### DIFF
--- a/exercises/atbash-cipher/atbash-cipher.spec.js
+++ b/exercises/atbash-cipher/atbash-cipher.spec.js
@@ -1,22 +1,22 @@
-import atbash from './atbash-cipher';
+import { encode } from './atbash-cipher';
 
 describe('encode', () => {
-  test('encodes no', () => expect(atbash.encode('no')).toEqual('ml'));
+  test('encodes no', () => expect(encode('no')).toEqual('ml'));
 
-  xtest('encodes yes', () => expect(atbash.encode('yes')).toEqual('bvh'));
+  xtest('encodes yes', () => expect(encode('yes')).toEqual('bvh'));
 
-  xtest('encodes OMG', () => expect(atbash.encode('OMG')).toEqual('lnt'));
+  xtest('encodes OMG', () => expect(encode('OMG')).toEqual('lnt'));
 
-  xtest('encodes O M G', () => expect(atbash.encode('O M G')).toEqual('lnt'));
+  xtest('encodes O M G', () => expect(encode('O M G')).toEqual('lnt'));
 
-  xtest('encodes long words', () => expect(atbash.encode('mindblowingly')).toEqual('nrmwy oldrm tob'));
+  xtest('encodes long words', () => expect(encode('mindblowingly')).toEqual('nrmwy oldrm tob'));
 
-  xtest('encodes numbers', () => expect(atbash.encode('Testing, 1 2 3, testing.'))
+  xtest('encodes numbers', () => expect(encode('Testing, 1 2 3, testing.'))
     .toEqual('gvhgr mt123 gvhgr mt'));
 
-  xtest('encodes sentences', () => expect(atbash.encode('Truth is fiction.')).toEqual('gifgs rhurx grlm'));
+  xtest('encodes sentences', () => expect(encode('Truth is fiction.')).toEqual('gifgs rhurx grlm'));
 
-  xtest('encodes all the things', () => expect(atbash.encode('The quick brown fox jumps over the lazy dog.'))
+  xtest('encodes all the things', () => expect(encode('The quick brown fox jumps over the lazy dog.'))
     .toEqual('gsvjf rxpyi ldmul cqfnk hlevi gsvoz abwlt'),
   );
 });

--- a/exercises/atbash-cipher/example.js
+++ b/exercises/atbash-cipher/example.js
@@ -14,12 +14,10 @@ function invert(character) {
   }
 }
 
-export default {
-  encode: (s) => {
+export const encode = s => {
     let encoded;
     const characters = [];
     [...s.toLowerCase()].forEach(invert, characters);
     encoded = insertSpacing(characters.join(''), 5);
     return encoded;
-  },
 };


### PR DESCRIPTION
As per issue #436:
- Change default import `atbash` to named import `{ encode }`.
- Change export statement of example.js from a default to a named export.