### PR TITLE
Fix unit tests for Bracket-push exercise

### DIFF
--- a/exercises/bracket-push/bracket-push.spec.js
+++ b/exercises/bracket-push/bracket-push.spec.js
@@ -1,35 +1,35 @@
-import bracket from './bracket-push';
+import { bracketPush } from './bracket-push';
 
 describe('bracket push', () => {
   test('checks for appropriate bracketing in a set of brackets', () => {
-    expect(bracket('{}')).toEqual(true);
+    expect(bracketPush('{}')).toEqual(true);
   });
 
   xtest('returns false for unclosed brackets', () => {
-    expect(bracket('{{')).toEqual(false);
+    expect(bracketPush('{{')).toEqual(false);
   });
 
   xtest('returns false if brackets are out of order', () => {
-    expect(bracket('}{')).toEqual(false);
+    expect(bracketPush('}{')).toEqual(false);
   });
 
   xtest('checks bracketing in more than one pair of brackets', () => {
-    expect(bracket('{}[]')).toEqual(true);
+    expect(bracketPush('{}[]')).toEqual(true);
   });
 
   xtest('checks bracketing in nested brackets', () => {
-    expect(bracket('{[]}')).toEqual(true);
+    expect(bracketPush('{[]}')).toEqual(true);
   });
 
   xtest('rejects brackets that are properly balanced but improperly nested', () => {
-    expect(bracket('{[}]')).toEqual(false);
+    expect(bracketPush('{[}]')).toEqual(false);
   });
 
   xtest('checks bracket closure with deeper nesting', () => {
-    expect(bracket('{[)][]}')).toEqual(false);
+    expect(bracketPush('{[)][]}')).toEqual(false);
   });
 
   xtest('checks bracket closure in a long string of brackets', () => {
-    expect(bracket('{[]([()])}')).toEqual(true);
+    expect(bracketPush('{[]([()])}')).toEqual(true);
   });
 });

--- a/exercises/bracket-push/example.js
+++ b/exercises/bracket-push/example.js
@@ -1,4 +1,4 @@
-const bracketPush = (input) => {
+export const bracketPush = (input) => {
   if (input.length === 0) {
     return true;
   }
@@ -34,5 +34,3 @@ const bracketPush = (input) => {
   }
   return false;
 };
-
-export default bracketPush;


### PR DESCRIPTION
As per issue #436:
- Change default import `bracket` to named import `{ bracketPush }`.
- Change all function calls in the test suite to `bracketPush`'
- Change export statement of example.js from a default to a named export.